### PR TITLE
Sitemap priority editor changed to slider (#49)

### DIFF
--- a/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.controller.js
+++ b/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.controller.js
@@ -17,7 +17,14 @@
 
         vm.priorityProperty = {
             label: "Priority",
-            description: "The priority for this document type"
+            description: "The priority for this document type",
+            view: "slider",
+            config: {
+                initVal1: 0,
+                minVal: 0,
+                maxVal: 1,
+                step: 0.1
+            }
         }
 
         vm.changeFrequencies = [
@@ -37,7 +44,7 @@
 
                     vm.hideFromSitemapProperty.value = settings.hideFromSitemap;
                     vm.changeFrequencyProperty.value = settings.changeFrequency;
-                    vm.priorityProperty.value = settings.priority;
+                    vm.priorityProperty.value = (settings.priority || vm.priorityProperty.config.initVal1).toString();
 
                     vm.loading = false;
                 });
@@ -49,12 +56,12 @@
                     contentTypeId: editorState.getCurrent().id,
                     hideFromSitemap: vm.hideFromSitemapProperty.value === "1" ? 1 : 0,
                     changeFrequency: vm.changeFrequencyProperty.value,
-                    priority: vm.priorityProperty.value
+                    priority: vm.priorityProperty.value > 0 ? vm.priorityProperty.value : undefined
                 }).then(function (response) {
-                    if (response.status !== 200) {
-                        notificationsService.error("Something went wrong while saving sitemap settings");
-                    }
-                });
+                if (response.status !== 200) {
+                    notificationsService.error("Something went wrong while saving sitemap settings");
+                }
+            });
         }
 
         $scope.$on("seoSettingsSubmitting",

--- a/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.controller.js
+++ b/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.controller.js
@@ -19,6 +19,7 @@
             label: "Priority",
             description: "The priority for this document type",
             view: "slider",
+            enabled: false,
             config: {
                 initVal1: 0,
                 minVal: 0,
@@ -44,7 +45,13 @@
 
                     vm.hideFromSitemapProperty.value = settings.hideFromSitemap;
                     vm.changeFrequencyProperty.value = settings.changeFrequency;
-                    vm.priorityProperty.value = (settings.priority || vm.priorityProperty.config.initVal1).toString();
+                    
+                    if (Utilities.isString(settings.priority) || Utilities.isNumber(settings.priority)) {
+                        vm.priorityProperty.value = settings.priority.toString();
+                        vm.priorityProperty.enabled = true;
+                    } else {
+                        vm.priorityProperty.enabled = false;
+                    }
 
                     vm.loading = false;
                 });
@@ -56,7 +63,7 @@
                     contentTypeId: editorState.getCurrent().id,
                     hideFromSitemap: vm.hideFromSitemapProperty.value === "1" ? 1 : 0,
                     changeFrequency: vm.changeFrequencyProperty.value,
-                    priority: vm.priorityProperty.value > 0 ? vm.priorityProperty.value : undefined
+                    priority: vm.priorityProperty.enabled ? vm.priorityProperty.value : undefined
                 }).then(function (response) {
                 if (response.status !== 200) {
                     notificationsService.error("Something went wrong while saving sitemap settings");

--- a/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
+++ b/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
@@ -21,25 +21,7 @@
         </div>
     </div>
 
-    <div class="control-group umb-control-group">
-        <div class="umb-el-wrap">
-            <div class="control-header">
-                <label class="control-label">{{vm.priorityProperty.label}}</label>
-                <small class="control-description">
-                    {{vm.priorityProperty.description}}
-                </small>
-            </div>
-            <div class="controls">
-                <div class="umb-property-editor">
-                    <input name="decimalField" class="umb-property-editor umb-number"
-                           type="number"
-                           ng-model="vm.priorityProperty.value"
-                           step="0.1"
-                           min="0"
-                           max="1"
-                           fix-number />
-                </div>
-            </div>
-        </div>
-    </div>
+    <umb-property property="vm.priorityProperty">
+        <umb-property-editor model="vm.priorityProperty"></umb-property-editor>
+    </umb-property>
 </div>

--- a/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
+++ b/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
@@ -21,7 +21,8 @@
         </div>
     </div>
 
-    <umb-property property="vm.priorityProperty">
-        <umb-property-editor model="vm.priorityProperty"></umb-property-editor>
+    <umb-property property="vm.priorityProperty">        
+        <umb-toggle checked="vm.priorityProperty.enabled" on-click="vm.priorityProperty.enabled = !vm.priorityProperty.enabled"></umb-toggle>        
+        <umb-property-editor ng-if="vm.priorityProperty.enabled" model="vm.priorityProperty"></umb-property-editor>
     </umb-property>
 </div>

--- a/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
+++ b/src/SeoToolkit.Umbraco.Sitemap/App_Plugins/SeoToolkit/Sitemap/Displays/DocumentType/sitemapSettings.html
@@ -23,6 +23,6 @@
 
     <umb-property property="vm.priorityProperty">        
         <umb-toggle checked="vm.priorityProperty.enabled" on-click="vm.priorityProperty.enabled = !vm.priorityProperty.enabled"></umb-toggle>        
-        <umb-property-editor ng-if="vm.priorityProperty.enabled" model="vm.priorityProperty"></umb-property-editor>
+        <umb-property-editor ng-show="vm.priorityProperty.enabled" model="vm.priorityProperty"></umb-property-editor>
     </umb-property>
 </div>


### PR DESCRIPTION
Adds the slider for #49 

The value `0` is submitted to the saving endpoint as `undefined` so it will be stored as `null` in the database. Which means there is no longer an option to set the priority to `0`.

If setting the priority to `0` should be available, we could maybe add a toggle input to enable the slider first? I'll leave it up to you to decide @patrickdemooij9 😉