### PR TITLE
Added option to allow saving invalid Robots.txt content (#44)

### DIFF
--- a/src/SeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtController.cs
+++ b/src/SeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtController.cs
@@ -31,13 +31,18 @@ namespace SeoToolkit.Umbraco.RobotsTxt.Core.Controllers
         public IActionResult Save(RobotsTxtSavePostModel model)
         {
             var content = model.Content ?? string.Empty;
-            var validationErrors = _robotsTxtService.Validate(content).ToArray();
-            if (validationErrors.Length > 0)
+            
+            // After saving the content with any validation errors, the user gets the option to save without validation.
+            if (!model.SkipValidation)
             {
-                return BadRequest(validationErrors.Select(it => new RobotsTxtValidationViewModel(it)));
+                var validationErrors = _robotsTxtService.Validate(content).ToArray();
+                if (validationErrors.Length > 0)
+                {
+                    return BadRequest(validationErrors.Select(it => new RobotsTxtValidationViewModel(it)));
+                }
             }
 
-            _robotsTxtService.SetContent(model.Content);
+            _robotsTxtService.SetContent(content);
             return Get();
         }
     }

--- a/src/SeoToolkit.Umbraco.RobotsTxt.Core/Models/PostModel/RobotsTxtSavePostModel.cs
+++ b/src/SeoToolkit.Umbraco.RobotsTxt.Core/Models/PostModel/RobotsTxtSavePostModel.cs
@@ -2,6 +2,7 @@
 {
     public class RobotsTxtSavePostModel
     {
+        public bool SkipValidation { get; set; }
         public string Content { get; set; }
     }
 }


### PR DESCRIPTION
Fix for #44 

Added an overlay when the robots.txt saved is invalid:
![image](https://user-images.githubusercontent.com/23453777/163692089-ef066593-7034-44af-8e48-6e3e244faee2.png)

When the 'Ignore and save' button is clicked, a `skipValidation` parameter is sent, which... skips the validation.

I'm not sure about the text of both the description and buttons, so any suggestions for these are more than welcome!