### PR TITLE
Draft for syncing metafields with usync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -487,3 +487,7 @@ $RECYCLE.BIN/
 **/wwwroot/umbraco/
 
 **/SeoToolkit.Umbraco.Site/App_Plugins/
+**/uSync/
+**/umbraco/Data/Umbraco.sqlite.db
+**/umbraco/Data/Umbraco.sqlite.db-shm
+**/umbraco/Data/Umbraco.sqlite.db-wal

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Interfaces/Services/IMetaFieldsValueService.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Interfaces/Services/IMetaFieldsValueService.cs
@@ -6,8 +6,8 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Services
 {
     public interface IMetaFieldsValueService
     {
-        Dictionary<string, object> GetUserValues(int nodeId);
-        void AddValues(int nodeId, Dictionary<string, object> values);
+        Dictionary<string, object> GetUserValues(int nodeId, string culture = null);
+        void AddValues(int nodeId, Dictionary<string, object> values, string culture = null);
         void Delete(int nodeId, string fieldAlias);
     }
 }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
@@ -23,26 +23,29 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
             _cache = appCaches.RuntimeCache;
         }
 
-        public Dictionary<string, object> GetUserValues(int nodeId)
+        public Dictionary<string, object> GetUserValues(int nodeId, string culture = null)
         {
-            var culture = GetCulture();
-            return _cache.GetCacheItem($"{BaseCacheKey}{nodeId}_{culture}", () => _repository.GetAllValues(nodeId, culture), TimeSpan.FromMinutes(30));
+            var iso = culture ?? GetCulture();
+            return _cache.GetCacheItem($"{BaseCacheKey}{nodeId}_{iso}", () => _repository.GetAllValues(nodeId, iso), TimeSpan.FromMinutes(30));
         }
 
-        public void AddValues(int nodeId, Dictionary<string, object> values)
+        public void AddValues(int nodeId, Dictionary<string, object> values, string culture = null)
         {
+            var iso = culture ?? GetCulture();
             foreach (var (key, value) in values)
             {
-                if (_repository.Exists(nodeId, key, GetCulture()))
-                    _repository.Update(nodeId, key, GetCulture(), value);
+                if (_repository.Exists(nodeId, key, iso))
+                    _repository.Update(nodeId, key, iso, value);
                 else
                 {
-                    _repository.Add(nodeId, key, GetCulture(), value);
+                    _repository.Add(nodeId, key, iso, value);
                 }
             }
             ClearCache(nodeId);
         }
 
+    
+        
         public void Delete(int nodeId, string fieldAlias)
         {
             _repository.Delete(nodeId, fieldAlias, GetCulture());

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
@@ -50,7 +50,7 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
 
         private string GetCulture()
         {
-            return _variationContextAccessor.VariationContext.Culture;
+            return _variationContextAccessor.VariationContext?.Culture ?? string.Empty;
         }
 
         private void ClearCache(int nodeId)

--- a/src/SeoToolkit.Umbraco.Site/SeoToolkit.Umbraco.Site.csproj
+++ b/src/SeoToolkit.Umbraco.Site/SeoToolkit.Umbraco.Site.csproj
@@ -45,6 +45,7 @@
     <Watch Remove="umbraco\**" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\SeoToolkit.Umbraco.uSync.Core\SeoToolkit.Umbraco.uSync.Core.csproj" />
     <ProjectReference Include="..\SeoToolkit.Umbraco\SeoToolkit.Umbraco.csproj" />
   </ItemGroup>
 

--- a/src/SeoToolkit.Umbraco.sln
+++ b/src/SeoToolkit.Umbraco.sln
@@ -49,6 +49,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.Umbraco.Redirect
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.Umbraco.Redirects.Core", "SeoToolkit.Umbraco.Redirects.Core\SeoToolkit.Umbraco.Redirects.Core.csproj", "{566D1DBF-EC21-405C-BB92-424C4A1C1B88}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "uSync", "uSync", "{0080FA37-4D4E-44E0-8235-740C3D557D77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.Umbraco.uSync.Core", "SeoToolkit.Umbraco.uSync.Core\SeoToolkit.Umbraco.uSync.Core.csproj", "{A509609B-306B-41ED-9115-C3319ED779D9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +127,10 @@ Global
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A509609B-306B-41ED-9115-C3319ED779D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A509609B-306B-41ED-9115-C3319ED779D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A509609B-306B-41ED-9115-C3319ED779D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A509609B-306B-41ED-9115-C3319ED779D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,6 +148,7 @@ Global
 		{5B460335-8786-4FA9-911B-AEC5A752B88C} = {5641B436-FCCB-4D1A-9D25-6A39B95031CB}
 		{7C9ABE0D-106C-48C0-B0CF-DBBCD8AF334E} = {B0B49325-8248-4DB8-889D-211D9408D7A5}
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88} = {B0B49325-8248-4DB8-889D-211D9408D7A5}
+		{A509609B-306B-41ED-9115-C3319ED779D9} = {0080FA37-4D4E-44E0-8235-740C3D557D77}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {551ADBA5-3DFB-4300-929C-2BE0DB346636}

--- a/src/SeoToolkit.Umbraco.uSync.Core/Composers/USyncComposer.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Composers/USyncComposer.cs
@@ -1,7 +1,10 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using SeoToolkit.Umbraco.uSync.Core.XmlTrackers;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Cms.Core.Models;
+using uSync.Core.Tracking;
 
 namespace SeoToolkit.Umbraco.uSync.Core.Composers;
 
@@ -10,5 +13,6 @@ public class USyncComposer : IComposer
     public void Compose(IUmbracoBuilder builder)
     {
         builder.Services.AddTransient<MetaFieldValuesSerializer, MetaFieldValuesSerializer>();
+        builder.Services.AddTransient<ISyncTrackerBase, SeoToolkitXmlTracker>();
     }
 }

--- a/src/SeoToolkit.Umbraco.uSync.Core/Composers/USyncComposer.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Composers/USyncComposer.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+
+namespace SeoToolkit.Umbraco.uSync.Core.Composers;
+
+public class USyncComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+        builder.Services.AddTransient<MetaFieldValuesSerializer, MetaFieldValuesSerializer>();
+    }
+}

--- a/src/SeoToolkit.Umbraco.uSync.Core/Constants/Serialization.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Constants/Serialization.cs
@@ -1,0 +1,9 @@
+﻿namespace SeoToolkit.Umbraco.uSync.Core.Constants;
+
+public static class Serialization
+{
+    public const string DocumentTypeSettingsDto = "DocumentTypeSettingsDto";
+    public const string MetaFieldValues = "MetaFieldValues";
+    
+    public const string RootName = "Content";
+}

--- a/src/SeoToolkit.Umbraco.uSync.Core/Handlers/MetaFieldValuesHandler.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Handlers/MetaFieldValuesHandler.cs
@@ -14,7 +14,7 @@ using uSync.Core.Serialization;
 
 namespace uSync.BackOffice.SyncHandlers.Handlers;
 
-[SyncHandler("seoToolkitMetaFieldValuesHandler", "SeoToolkit Meta Fields", "seoToolkitContent", uSyncConstants.Priorites.Content
+[SyncHandler("seoToolkitMetaFieldValuesHandler", "SeoToolkit Meta Fields", "SeoToolkitMetaFields", uSyncConstants.Priorites.Content
     , Icon = "icon-list", IsTwoPass = true, EntityType = Constants.UdiEntityType.Document)]
 public class MetaFieldValuesHandler : ContentHandlerBase<IContent, IContentService>, ISyncHandler
 {

--- a/src/SeoToolkit.Umbraco.uSync.Core/Handlers/MetaFieldValuesHandler.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Handlers/MetaFieldValuesHandler.cs
@@ -1,0 +1,77 @@
+﻿using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.Core;
+using uSync.Core.Serialization;
+
+namespace uSync.BackOffice.SyncHandlers.Handlers;
+
+[SyncHandler("seoToolkitMetaFieldValuesHandler", "SeoToolkit Meta Fields", "seoToolkitContent", uSyncConstants.Priorites.Content
+    , Icon = "icon-list", IsTwoPass = true, EntityType = Constants.UdiEntityType.Document)]
+public class MetaFieldValuesHandler : ContentHandlerBase<IContent, IContentService>, ISyncHandler
+{
+    private readonly MetaFieldValuesSerializer _metaFieldValuesSerializer;
+    private readonly IContentService _contentService;
+
+    /// <summary>
+    ///  the default group for which events matter (content group)
+    /// </summary>
+    public override string Group => uSyncConstants.Groups.Content;
+
+    public MetaFieldValuesHandler(MetaFieldValuesSerializer metaFieldValuesSerializer,IContentService contentService, ILogger<MetaFieldValuesHandler> logger,
+        IEntityService entityService, AppCaches appCaches, IShortStringHelper shortStringHelper,
+        SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfigService,
+        ISyncItemFactory syncItemFactory) : base(logger, entityService, appCaches, shortStringHelper, syncFileService,
+        mutexService, uSyncConfigService, syncItemFactory)
+    {
+        _metaFieldValuesSerializer = metaFieldValuesSerializer;
+        _contentService = contentService;
+        
+    }
+
+    public override IEnumerable<uSyncAction> Export(IContent? item, string folder, HandlerSettings config)
+    {
+        if (item == null)
+            return uSyncAction.Fail(nameof(item), typeof(IContent).ToString(), ChangeType.Fail, "Item not set",
+                new ArgumentNullException(nameof(item))).AsEnumerableOfOne();
+
+        var filename = GetPath(folder, item, config.GuidNames, config.UseFlatStructure)
+            .ToAppSafeFileName();
+        
+        var attempt = _metaFieldValuesSerializer.Serialize(item, new SyncSerializerOptions(config.Settings));
+        if (!attempt.Success)
+            return uSyncActionHelper<XElement>.SetAction(attempt, filename, GetItemKey(item), this.Alias)
+                .AsEnumerableOfOne();
+        
+        if (ShouldExport(attempt.Item, config))
+        {
+            // only write the file to disk if it should be exported.
+            syncFileService.SaveXElement(attempt.Item, filename);
+        }
+        else
+        {
+            return uSyncAction.SetAction(true, filename, type: typeof(IContent).ToString(),
+                    change: ChangeType.NoChange, message: "Not Exported (Based on config)", filename: filename)
+                .AsEnumerableOfOne();
+        }
+
+        return uSyncActionHelper<XElement>.SetAction(attempt, filename, GetItemKey(item), this.Alias)
+            .AsEnumerableOfOne();
+    }
+
+
+    public override IEnumerable<uSyncAction> Import(XElement node, string filename, HandlerSettings config, SerializerFlags flags)
+    {
+        var attempt = _metaFieldValuesSerializer.Deserialize(node, new SyncSerializerOptions(config.Settings));
+        return uSyncActionHelper<IContent>.SetAction(attempt, filename,node.GetKey(), this.Alias)
+            .AsEnumerableOfOne();
+    }
+}

--- a/src/SeoToolkit.Umbraco.uSync.Core/SeoToolkit.Umbraco.uSync.Core.csproj
+++ b/src/SeoToolkit.Umbraco.uSync.Core/SeoToolkit.Umbraco.uSync.Core.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="uSync" Version="10.1.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SeoToolkit.Umbraco.MetaFields.Core\SeoToolkit.Umbraco.MetaFields.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/SeoToolkit.Umbraco.uSync.Core/Serializers/MetaFieldValuesSerializer.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/Serializers/MetaFieldValuesSerializer.cs
@@ -1,0 +1,195 @@
+﻿using System.Drawing;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Services;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Entities;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Extensions;
+using uSync.Core;
+using uSync.Core.Mapping;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+using uSync.Core.Serialization.Serializers;
+
+namespace SeoToolkit.Umbraco.uSync.Core.Serializers;
+
+[SyncSerializer("cfeaa2d0-8af5-4ef4-9dd6-3b696df18189", "SeoToolkit.MetaFieldSerializer", Constants.Serialization.MetaFieldValues)]
+public class MetaFieldValuesSerializer : ContentSerializerBase<IContent>
+{
+    private readonly IShortStringHelper _shortStringHelper;
+    private readonly IEntityService _entityService;
+    private readonly IMetaFieldsValueService _metaFieldsValueService;
+    private readonly IContentService _contentService;
+
+    public MetaFieldValuesSerializer(IEntityService entityService, ILocalizationService localizationService,
+        IRelationService relationService, IShortStringHelper shortStringHelper,
+        ILogger<MetaFieldValuesSerializer> logger,
+        SyncValueMapperCollection syncMappers, IMetaFieldsValueService metaFieldsValueService,
+        IContentService contentService) : base(entityService, localizationService, relationService, shortStringHelper,
+        logger, UmbracoObjectTypes.Document, syncMappers)
+    {
+        _entityService = entityService;
+        _shortStringHelper = shortStringHelper;
+        _metaFieldsValueService = metaFieldsValueService;
+        _contentService = contentService;
+    }
+
+    private XElement InitializeNode(IContent item)
+    {
+        return new XElement(Constants.Serialization.RootName, new XAttribute("Key", ItemKey(item)), new XAttribute("Alias", ItemAlias(item)));
+    }
+
+    public new SyncAttempt<IContent> Deserialize(XElement node, SyncSerializerOptions options)
+    {
+        if (node.IsEmptyItem())
+            return ProcessAction(node, options);
+        if (!IsValid(node))
+            throw new FormatException("XML Not valid for type " + this.ItemType);
+        if (!options.Force && this.IsCurrent(node, options) <= ChangeType.NoChange)
+            return SyncAttempt<IContent>.Succeed(node.GetAlias(), ChangeType.NoChange);
+        var syncAttempt1 = this.CanDeserialize(node, options);
+        if (!syncAttempt1.Success)
+            return syncAttempt1;
+        logger.LogDebug("Base: Deserializing {0}", (object) this.ItemType);
+        var syncAttempt2 = DeserializeCore(node, options);
+        if (syncAttempt2.Success)
+        {
+            logger.LogDebug("Base: Deserialize Core Success {0}", (object) this.ItemType);
+            if (!syncAttempt2.Saved && !options.Flags.HasFlag((Enum) SerializerFlags.DoNotSave))
+            {
+                logger.LogDebug("Base: Serializer Saving (No DoNotSaveFlag) {0}", (object) this.ItemAlias(syncAttempt2.Item));
+                SaveItem(syncAttempt2.Item);
+            }
+            if (options.OnePass)
+            {
+                logger.LogDebug("Base: Processing item in one pass {0}", (object) this.ItemAlias(syncAttempt2.Item));
+                var syncAttempt3 = this.DeserializeSecondPass(syncAttempt2.Item, node, options);
+                logger.LogDebug("Base: Second Pass Result {0} {1}", (object) this.ItemAlias(syncAttempt2.Item), (object) syncAttempt3.Success);
+                return syncAttempt3;
+            }
+        }
+        return syncAttempt2;
+    }
+
+    protected override SyncAttempt<XElement> SerializeCore(IContent item, SyncSerializerOptions options)
+    {
+        var node = InitializeNode(item);
+
+        var fields = _metaFieldsValueService.GetUserValues(item.Id);
+
+        if (!fields.Any())
+        {
+            return SyncAttempt<XElement>.Fail(item.Name, ChangeType.NoChange, "No Meta Fields");
+        }
+
+        node.Add(fields.Select(field => new XElement(field.Key, field.Value)));
+
+        return SyncAttempt<XElement>.Succeed(item.Name, node, typeof(IContent), ChangeType.Export);
+    }
+
+    protected override SyncAttempt<IContent> DeserializeCore(XElement node, SyncSerializerOptions options)
+    {
+        var attempt = FindOrCreate(node);
+        var item = GetDictionaryValues(node);
+        if (attempt.Success && attempt.Result != null)
+        {
+            Save(attempt.Result.Id, item);
+            return SyncAttempt<IContent>.Succeed(node.GetAlias(), attempt.Result,
+                typeof(IContent), ChangeType.Import);
+        }
+
+
+        return SyncAttempt<IContent>.Fail(node.GetAlias(), attempt.Result, ChangeType.Fail,
+            "Failed to find or create content", attempt.Exception);
+    }
+
+    public override bool IsValid(XElement node) => node != null! && node.GetAlias() != null && node.Name == Constants.Serialization.RootName;
+
+    public override ChangeType IsCurrent(XElement node, SyncSerializerOptions options)
+    {
+        var content = _contentService.GetById(node.GetKey());
+        var currentValues = _metaFieldsValueService.GetUserValues(content.Id);
+        var newValues = GetDictionaryValues(node);
+        
+        if (currentValues.Count != newValues.Count)
+            return ChangeType.Import;
+
+        if (currentValues.Intersect(newValues).Count() != currentValues.Count)
+            return ChangeType.Import;
+        
+        
+        return ChangeType.NoChange;
+    }
+    
+    public override IContent FindItem(int id)
+    {
+        var item = _contentService.GetById(id);
+        if (item != null)
+        {
+            AddToNameCache(id, item.Key, item.Name);
+            return item;
+        }
+
+        return null!;
+    }
+    
+
+    public override IContent FindItem(Guid key)
+        => _contentService.GetById(key)!;
+
+    public override void SaveItem(IContent item)
+    {
+       //We do not need to save the contentItem itself, but we do need to override this method
+    }
+
+    public override void DeleteItem(IContent item)
+    {
+        //We do not need to delete the contentItem itself, but we do need to override this method
+        //Maybe we should delete meta-field values for a content item when it is deleted?
+    }
+
+
+    private void Save(int nodeId, Dictionary<string, object?> item)
+    {
+        _metaFieldsValueService.AddValues(nodeId, item);
+    }
+
+    private Dictionary<string, object> GetDictionaryValues(XElement node)
+    {
+        return node.Descendants()
+            .ToDictionary<XElement?, string, object>(descendantNode => descendantNode.Name.ToString(),
+                descendantNode => descendantNode.Value);
+    }
+
+
+    protected override Attempt<IContent> CreateItem(string alias, ITreeEntity parent, string itemType)
+    {
+        var parentId = parent != null! ? parent.Id : -1;
+        var item = _contentService.Create(alias, parentId, itemType);
+        if (item == null!)
+            return Attempt.Fail(item, new ArgumentException($"Unable to create content item of type {itemType}"))!;
+
+        return Attempt.Succeed(item)!;
+    }
+
+    protected override uSyncChange HandleTrashedState(IContent item, bool trashed)
+    {
+        // We do not need to handle trashed state, the default handler does this for us.
+        return null!;
+
+    }
+
+    protected override IContent FindAtRoot(string alias)
+    {
+        var rootNodes = _contentService.GetRootContent().ToList();
+        if (rootNodes.Any())
+        {
+            return rootNodes.FirstOrDefault(x => x.Name!.ToSafeAlias(shortStringHelper).InvariantEquals(alias))!;
+        }
+
+        return null!;
+    }
+}

--- a/src/SeoToolkit.Umbraco.uSync.Core/XmlTrackers/SeoToolkitXmlTracker.cs
+++ b/src/SeoToolkit.Umbraco.uSync.Core/XmlTrackers/SeoToolkitXmlTracker.cs
@@ -1,0 +1,29 @@
+﻿using System.Xml.Linq;
+using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using Umbraco.Cms.Core.Models;
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+using uSync.Core.Tracking;
+using uSync.Core.Tracking.Impliment;
+
+namespace SeoToolkit.Umbraco.uSync.Core.XmlTrackers;
+
+public class SeoToolkitXmlTracker :
+    SyncXmlTracker<IContent>,
+    ISyncTracker<IContent>,
+    ISyncTrackerBase
+{
+    public override List<TrackingItem> TrackingItems => new List<TrackingItem>()
+    {
+        TrackingItem.Many("Property - *", "/*/Value", "@Culture"),
+
+    };
+
+    public SeoToolkitXmlTracker(SyncSerializerCollection serializers, MetaFieldValuesSerializer serializer) : base(serializers)
+    {
+        this.serializer = serializer;
+    }
+
+   
+}


### PR DESCRIPTION
Fixes [39](https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/39)

The initial draft for uSync implementation. 

- [x] Sync meta field- / SEO field values
- [x]  Add reporting to meta fields
- [x]  Support language variants

- [ ] Sync SEO settings
- [ ] Add reporting to Seo settings

@patrickdemooij9 take a look and let me know if you want any changes, I'll look into synching the settings portion either later today or tomorrow morning.


Other Notes:

- I've used the [default content serializer](https://github.com/KevinJump/uSync/blob/ed629c5dffe42b029852d027abbf56d2115d0b87/uSync.Core/Serialization/Serializers/ContentSerializer.cs) as the basis
- Maybe there should also be some logic in place to detect whether the open graph image exists on import