### PR TITLE
Added robot headers to document type settings

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Common/Converters/EditorConverters/CheckboxlistConverter.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Common/Converters/EditorConverters/CheckboxlistConverter.cs
@@ -1,0 +1,32 @@
+﻿using Newtonsoft.Json.Linq;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Converters;
+
+namespace SeoToolkit.Umbraco.MetaFields.Core.Common.Converters.EditorConverters
+{
+    public class CheckboxlistConverter : IEditorValueConverter
+    {
+        public object ConvertDatabaseToObject(object value)
+        {
+            if (value is null) return null;
+
+            return value.ToString().Split(',');
+        }
+
+        public object ConvertEditorToDatabaseValue(object value)
+        {
+            if (!(value is JArray array)) return null;
+            return string.Join(',', array);
+        }
+
+        public object ConvertObjectToEditorValue(object value)
+        {
+            return value;
+        }
+
+        public bool IsEmpty(object value)
+        {
+            if ((value as string[])?.Length > 0) return false;
+            return true;
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditEditors/SeoCheckboxlistEditEditor.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditEditors/SeoCheckboxlistEditEditor.cs
@@ -1,0 +1,24 @@
+﻿using SeoToolkit.Umbraco.MetaFields.Core.Common.Converters.EditorConverters;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Converters;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.SeoField;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.Converters;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SeoToolkit.Umbraco.MetaFields.Core.Common.SeoFieldEditEditors
+{
+    public class SeoCheckboxlistEditEditor : ISeoFieldEditEditor
+    {
+        public string View => "checkboxlist";
+        public Dictionary<string, object> Config { get; }
+        public IEditorValueConverter ValueConverter => new CheckboxlistConverter();
+
+        public SeoCheckboxlistEditEditor(CheckboxItem[] items)
+        {
+            Config = new Dictionary<string, object>
+            {
+                {"prevalues",  items}
+            };
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditors/SeoFieldPropertyEditor.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditors/SeoFieldPropertyEditor.cs
@@ -7,10 +7,18 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Common.SeoFieldEditors
 {
     public class SeoFieldPropertyEditor : ISeoFieldEditor, ISeoFieldEditorDefaultValue
     {
+        private const string PreValueKey = "isPreValue";
+
         public string View => "/App_Plugins/SeoToolkit/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.html";
 
         public Dictionary<string, object> Config { get; }
         public IEditorValueConverter ValueConverter { get; }
+
+        public bool IsPreValue
+        {
+            get { return Config.ContainsKey(PreValueKey) && (bool)Config[PreValueKey]; }
+            set { Config[PreValueKey] = value; }
+        }
 
         private object _defaultValue;
 

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Composers/MetaFieldsComposer.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Composers/MetaFieldsComposer.cs
@@ -65,7 +65,8 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Composers
                 .Add<OpenGraphTitleField>()
                 .Add<OpenGraphDescriptionField>()
                 .Add<OpenGraphImageField>()
-                .Add<CanonicalUrlField>();
+                .Add<CanonicalUrlField>()
+                .Add<RobotsField>();
 
             builder.WithCollectionBuilder<SeoConverterCollectionBuilder>()
                 .Add<TextSeoValueConverter>()

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Constants/SeoFieldAliasConstants.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Constants/SeoFieldAliasConstants.cs
@@ -8,5 +8,6 @@
         public const string OpenGraphDescription = "openGraphDescription";
         public const string OpenGraphImage = "openGraphImage";
         public const string CanonicalUrl = "canonicalUrl";
+        public const string Robots = "robots";
     }
 }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Controllers/MetaFieldsController.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Controllers/MetaFieldsController.cs
@@ -75,7 +75,7 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Controllers
             return new JsonResult(new MetaFieldsSettingsViewModel
             {
                 Groups = _groupCollection.Select(it => new SeoFieldGroupViewModel(it)).ToArray(),
-                Fields = metaTags.Fields.Select(it =>
+                Fields = metaTags.Fields.Where(it => it.Key.EditEditor != null).Select(it =>
                 {
                     var (key, value) = it;
                     var userValue = userValues.ContainsKey(key.Alias)

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/Converters/CheckboxItem.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/Converters/CheckboxItem.cs
@@ -1,0 +1,14 @@
+﻿namespace SeoToolkit.Umbraco.MetaFields.Core.Models.Converters
+{
+    public class CheckboxItem
+    {
+        public string Label { get; set; }
+        public string Value { get; set; }
+
+        public CheckboxItem(string label, string value)
+        {
+            Label = label;
+            Value = value;
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/RobotsField.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/RobotsField.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Html;
+using SeoToolkit.Umbraco.MetaFields.Core.Common.Converters.EditorConverters;
+using SeoToolkit.Umbraco.MetaFields.Core.Common.SeoFieldEditEditors;
+using SeoToolkit.Umbraco.MetaFields.Core.Common.SeoFieldEditors;
+using SeoToolkit.Umbraco.MetaFields.Core.Constants;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.SeoField;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.Converters;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Cms.Core.Composing;
+
+namespace SeoToolkit.Umbraco.MetaFields.Core.Models.SeoField
+{
+    [Weight(600)]
+    public class RobotsField : SeoField<string[]>
+    {
+        public override string Title => "Robots";
+        public override string Alias => SeoFieldAliasConstants.Robots;
+        public override string Description => "Robot tags for your page";
+
+        public override string GroupAlias => SeoFieldGroupConstants.Others;
+
+        public override ISeoFieldEditor Editor { get; }
+        public override ISeoFieldEditEditor EditEditor { get; }
+
+        public RobotsField()
+        {
+            var items = new CheckboxItem[]
+            {
+                new CheckboxItem("No index", "noindex"),
+                new CheckboxItem("No follow", "nofollow"),
+                new CheckboxItem("No archive", "noarchive"),
+                new CheckboxItem("No search box", "nositelinkssearchbox"),
+                new CheckboxItem("No snippet", "nosnippet"),
+                new CheckboxItem("Index if embedded", "indexifembedded"),
+                new CheckboxItem("No translate", "notranslate"),
+                new CheckboxItem("No image index", "noimageindex")
+            };
+
+            Editor = new SeoFieldPropertyEditor("checkboxlist", new CheckboxlistConverter())
+            {
+                IsPreValue = true
+            };
+            Editor.Config.Add("prevalues", items);
+
+            //EditEditor = new SeoCheckboxlistEditEditor(items);
+        }
+
+        protected override HtmlString Render(string[] value)
+        {
+            if (value is null || value.Length == 0) return HtmlString.Empty;
+
+            return new HtmlString($"<meta name=\"robots\" content=\"{string.Join(',', value)}\">");
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/ViewModels/SeoFieldViewModel.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/ViewModels/SeoFieldViewModel.cs
@@ -33,6 +33,8 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Models.SeoField.ViewModels
 
         public SeoFieldViewModel(ISeoField field, DocumentTypeValueDto value) : this(field)
         {
+            if (value is null) return;
+
             Value = field.Editor.ValueConverter.ConvertObjectToEditorValue(value.Value);
             UseInheritedValue = value.UseInheritedValue;
         }

--- a/src/SeoToolkit.Umbraco.MetaFields/wwwroot/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.controller.js
+++ b/src/SeoToolkit.Umbraco.MetaFields/wwwroot/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.controller.js
@@ -9,7 +9,14 @@
 
         vm.model = {
             view: vm.field.editor.config.view,
+            config: vm.field.editor.config,
             value: vm.field.value
+        }
+
+        if (vm.field.editor.config.isPreValue) {
+            vm.isPreValue = vm.field.editor.config.isPreValue;
+        } else {
+            vm.isPreValue = false;
         }
 
         function init()

--- a/src/SeoToolkit.Umbraco.MetaFields/wwwroot/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.html
+++ b/src/SeoToolkit.Umbraco.MetaFields/wwwroot/MetaFields/Interface/SeoFieldEditors/PropertyEditor/propertyEditor.html
@@ -1,5 +1,7 @@
 ﻿<div class="umb-el-wrap" ng-controller="SeoToolkit.SeoFieldEditors.PropertyEditorController as vm">
-    <umb-property-editor model="vm.model">
+    <umb-property-editor model="vm.model" ng-if="!vm.isPreValue">
+    </umb-property-editor>
+    <umb-property-editor model="vm.model" ng-if="vm.isPreValue" is-pre-value="{{vm.isPreValue}}">
     </umb-property-editor>
     <small class="control-description" ng-if="vm.field.editor.config.extraInformation">
         {{vm.field.editor.config.extraInformation}}


### PR DESCRIPTION
Part of https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/123

This only introduces the robot headers to the document type settings for now. Adding them to the content settings will take a bit more time as I'll have to figure out how this would work with fallbacks. But this change can already be merged and used