### PR TITLE
Updated Umbraco marketplace listing

### DIFF
--- a/umbraco-marketplace-seotoolkit.umbraco.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.json
@@ -1,0 +1,5 @@
+{
+    "Category": "Search",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.metafields.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.metafields.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.redirects.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.redirects.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.robotstxt.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.robotstxt.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.scriptmanager.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.scriptmanager.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.siteaudit.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.siteaudit.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}

--- a/umbraco-marketplace-seotoolkit.umbraco.sitemap.json
+++ b/umbraco-marketplace-seotoolkit.umbraco.sitemap.json
@@ -1,0 +1,6 @@
+{
+    "Category": "Search",
+    "IsSubPackageOf": "SeoToolkit.Umbraco",
+    "LicenseTypes": [ "Free" ],
+    "PackageType": "Package"
+}


### PR DESCRIPTION
I noted you'd listed this package on the Umbraco marketplace, so firstly, thanks for taking the time to do that.  I noticed though that we only have the details collected from NuGet for the package... which is fine, but to help it to be found more easily it's possible to provide additional information, as is discussed [here](https://marketplace.umbraco.com/listing).

To get started with this I've created this PR, which will at least ensure your package is listed under what looks to be the appropriate category.  I've also made use of the package nesting feature we have, so the "sub-packages" can be listed on the page of the main package, and only the main one appears in the package listing from the category links or search.  Up to you if you prefer that, but I think it's a cleaner listing in this way.

You can of course add more information, like tags, links, developer information, or extended descriptions and readme information.  I hope that's useful for you.
