### PR TITLE
Draft for uSync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -487,3 +487,4 @@ $RECYCLE.BIN/
 **/wwwroot/umbraco/
 
 **/SeoToolkit.Umbraco.Site/App_Plugins/
+src/SeoToolkit.Umbraco.Site/uSync/

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Repositories/SeoValueRepository/IMetaFieldsValueRepository.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Repositories/SeoValueRepository/IMetaFieldsValueRepository.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoSettings.Database;
 
 namespace SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository
 {
@@ -10,5 +12,6 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository
         bool Exists(int nodeId, string fieldAlias, string culture);
 
         Dictionary<string, object> GetAllValues(int nodeId, string culture);
+        IEnumerable<IGrouping<int, MetaFieldsValueEntity>> GetAll();
     }
 }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Repositories/SeoValueRepository/MetaFieldsDatabaseRepository.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Repositories/SeoValueRepository/MetaFieldsDatabaseRepository.cs
@@ -74,5 +74,13 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository
                     .ToDictionary(it => it.Alias, it => JsonConvert.DeserializeObject(it.UserValue));
             }
         }
+
+        public IEnumerable<IGrouping<int, MetaFieldsValueEntity>> GetAll()
+        {
+            using var scope = _scopeProvider.CreateScope();
+            var values = scope.Database
+                .Fetch<MetaFieldsValueEntity>(scope.SqlContext.Sql()).GroupBy(it => it.NodeId);
+            return values;
+        }
     }
 }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Services;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoSettings.Database;
 using SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository;
 
 namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
@@ -42,6 +44,11 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
                 }
             }
             ClearCache(nodeId);
+        }
+
+        public IEnumerable<IGrouping<int, MetaFieldsValueEntity>> GetAll()
+        {
+            return _repository.GetAll();
         }
 
         public void Delete(int nodeId, string fieldAlias, string culture = null)

--- a/src/SeoToolkit.Umbraco.Site/SeoToolkit.Umbraco.Site.csproj
+++ b/src/SeoToolkit.Umbraco.Site/SeoToolkit.Umbraco.Site.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="clean" Version="2.0.0-beta002" />
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.6" />
+    <PackageReference Include="uSync" Version="11.0.2" />
     <RuntimeHostConfigurationOption Include="System.Globalization.AppLocalIcu" Value="68.2" />
   </ItemGroup>
 
@@ -46,6 +47,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SeoToolkit.Umbraco\SeoToolkit.Umbraco.csproj" />
+    <ProjectReference Include="..\SeoToolkit.uSync\SeoToolkit.uSync.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/SeoToolkit.Umbraco.Site/appsettings-schema.json
+++ b/src/SeoToolkit.Umbraco.Site/appsettings-schema.json
@@ -3883,6 +3883,9 @@
     },
     {
       "$ref": "appsettings-schema.Umbraco.Cms.json#"
+    },
+    {
+      "$ref": "appsettings-schema.usync.json#"
     }
   ]
 }

--- a/src/SeoToolkit.Umbraco.Site/appsettings-schema.usync.json
+++ b/src/SeoToolkit.Umbraco.Site/appsettings-schema.usync.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "uSyncAppSettings",
+  "type": "object",
+  "properties": {
+    "uSync": {
+      "$ref": "#/definitions/USyncuSyncDefinition"
+    }
+  },
+  "definitions": {
+    "USyncuSyncDefinition": {
+      "type": "object",
+      "description": "Configuration of uSync settings",
+      "properties": {
+        "Settings": {
+          "description": "uSync settings",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/USyncBackOfficeConfigurationuSyncSettings"
+            }
+          ]
+        },
+        "ForceFips": {
+          "type": "boolean",
+          "description": "Force uSync to use FIPS compliant hashing algorthims when comparing files"
+        },
+        "Sets": {
+          "description": "Settings of Handler sets",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/USyncuSyncSetsDefinition"
+            }
+          ]
+        },
+        "AutoTemplates": {
+          "description": "Settings for the AutoTemplates package, (dynamic adding of templates based on files on disk)",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/USyncAutoTemplatesDefinition"
+            }
+          ]
+        }
+      }
+    },
+    "USyncBackOfficeConfigurationuSyncSettings": {
+      "type": "object",
+      "description": "uSync Settings",
+      "properties": {
+        "RootFolder": {
+          "type": "string",
+          "description": "Location where all uSync files are saved by default",
+          "default": "uSync/v9/"
+        },
+        "DefaultSet": {
+          "type": "string",
+          "description": "The default handler set to use on all notification triggered events",
+          "default": "Default"
+        },
+        "ImportAtStartup": {
+          "type": "string",
+          "description": "Import when Umbraco boots (can be group name or 'All' so everything is done, blank or 'none' == off)",
+          "default": "None"
+        },
+        "ExportAtStartup": {
+          "type": "string",
+          "description": "Export when Umbraco boots",
+          "default": "None"
+        },
+        "ExportOnSave": {
+          "type": "string",
+          "description": "Export when an item is saved in Umbraco",
+          "default": "All"
+        },
+        "UiEnabledGroups": {
+          "type": "string",
+          "description": "The handler groups that are enabled in the UI.",
+          "default": "All"
+        },
+        "ReportDebug": {
+          "type": "boolean",
+          "description": "Debug reports (creates an export into a temp folder for comparison)",
+          "default": false
+        },
+        "AddOnPing": {
+          "type": "boolean",
+          "description": "Ping the AddOnUrl to get the json used to show the addons dashboard",
+          "default": true
+        },
+        "RebuildCacheOnCompletion": {
+          "type": "boolean",
+          "description": "Pre Umbraco 8.4 - rebuild the cache was needed after content was imported",
+          "default": false
+        },
+        "FailOnMissingParent": {
+          "type": "boolean",
+          "description": "Fail if the items parent is not in umbraco or part of the batch being imported",
+          "default": false
+        },
+        "CacheFolderKeys": {
+          "type": "boolean",
+          "description": "Should folder keys be cached (for speed)",
+          "default": true
+        },
+        "ShowVersionCheckWarning": {
+          "type": "boolean",
+          "description": "Show a version check warning to the user if the folder version is less than the version expected by uSync.",
+          "default": true
+        },
+        "CustomMappings": {
+          "type": "object",
+          "description": "Custom mapping keys, allows users to add a simple config mapping to make one property type to behave like an existing one",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "SignalRRoot": {
+          "type": "string",
+          "description": "location of SignalR hub script",
+          "default": ""
+        },
+        "EnableHistory": {
+          "type": "boolean",
+          "description": "Should the history view be on of off ? ",
+          "default": true
+        },
+        "DefaultExtension": {
+          "type": "string",
+          "description": "Default file extension for the uSync files. ",
+          "default": "config"
+        },
+        "ImportOnFirstBoot": {
+          "type": "boolean",
+          "description": "Import the uSync folder on the first boot. ",
+          "default": false
+        },
+        "FirstBootGroup": {
+          "type": "string",
+          "description": "Handler group(s) to run on first boot, default is All (so full import)",
+          "default": "All"
+        },
+        "DisableDashboard": {
+          "type": "boolean",
+          "description": "Disable the default dashboard (so people can't accedently press the buttons).",
+          "default": "false"
+        },
+        "SummaryDashboard": {
+          "type": "boolean",
+          "description": "summerize results (for when there are loads and loads of items)\n            ",
+          "default": "false"
+        },
+        "SummaryLimit": {
+          "type": "integer",
+          "description": "limit of items to display before flicking to summary view. (this is per handler)\n            ",
+          "format": "int32",
+          "default": 1000
+        }
+      }
+    },
+    "USyncuSyncSetsDefinition": {
+      "type": "object",
+      "properties": {
+        "Default": {
+          "$ref": "#/definitions/USyncBackOfficeConfigurationuSyncHandlerSetSettings"
+        }
+      }
+    },
+    "USyncBackOfficeConfigurationuSyncHandlerSetSettings": {
+      "type": "object",
+      "description": "Settings for a handler set (group of handlers)",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Is this handler set enabled",
+          "default": true
+        },
+        "HandlerGroups": {
+          "type": "array",
+          "description": "List of groups handlers can belong to.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "DisabledHandlers": {
+          "type": "array",
+          "description": "List of disabled handlers",
+          "items": {
+            "type": "string"
+          }
+        },
+        "HandlerDefaults": {
+          "description": "Default settings for all handlers",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/USyncBackOfficeConfigurationHandlerSettings"
+            }
+          ]
+        },
+        "Handlers": {
+          "type": "object",
+          "description": "Settings for named handlers ",
+          "additionalProperties": {
+            "$ref": "#/definitions/USyncBackOfficeConfigurationHandlerSettings"
+          }
+        },
+        "IsSelectable": {
+          "type": "boolean",
+          "description": "for handlers to appear in the drop down on the dashboard they have to be selectable\n            "
+        }
+      }
+    },
+    "USyncBackOfficeConfigurationHandlerSettings": {
+      "type": "object",
+      "description": "Settings to control who a handler works",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Is handler enabled or disabled",
+          "default": true
+        },
+        "Actions": {
+          "type": "array",
+          "description": "List of actions the handler is configured for. ",
+          "items": {
+            "type": "string"
+          }
+        },
+        "UseFlatStructure": {
+          "type": "boolean",
+          "description": "Should use a flat folder structure when exporting items",
+          "default": true
+        },
+        "GuidNames": {
+          "type": "boolean",
+          "description": "Items should be saved with their guid/key value as the filename",
+          "default": false
+        },
+        "FailOnMissingParent": {
+          "type": "boolean",
+          "description": "Imports should fail if the parent item is missing (if false, item be importated go a close as possible to location)",
+          "default": false
+        },
+        "Group": {
+          "type": "string",
+          "description": "Override the group the handler belongs too.",
+          "default": ""
+        },
+        "Settings": {
+          "type": "object",
+          "description": "Additional settings for the handler",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "USyncAutoTemplatesDefinition": {
+      "type": "object",
+      "properties": {
+        "Enabled": {
+          "type": "boolean",
+          "description": "Enable AutoTemplates feature",
+          "default": false
+        },
+        "Delete": {
+          "type": "boolean",
+          "description": "Delete templates from Umbraco if the file is missing from disk",
+          "default": false
+        },
+        "Delay": {
+          "type": "integer",
+          "description": "Amount of time (milliseconds) to wait after file change event before applying changes",
+          "format": "int32",
+          "default": 1000
+        }
+      }
+    }
+  }
+}

--- a/src/SeoToolkit.Umbraco.Site/appsettings.json
+++ b/src/SeoToolkit.Umbraco.Site/appsettings.json
@@ -11,7 +11,7 @@
     }
   },
   "ConnectionStrings": {
-    "umbracoDbDSN": "Server=localhost;Database=uSeoToolkitV11;Integrated Security=true"
+    "umbracoDbDSN": "Server=(localdb)\\MSSQLLocalDB;Database=uSeoToolkit;Integrated Security=true"
   },
   "Umbraco": {
     "CMS": {

--- a/src/SeoToolkit.Umbraco.sln
+++ b/src/SeoToolkit.Umbraco.sln
@@ -49,6 +49,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.Umbraco.Redirect
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.Umbraco.Redirects.Core", "SeoToolkit.Umbraco.Redirects.Core\SeoToolkit.Umbraco.Redirects.Core.csproj", "{566D1DBF-EC21-405C-BB92-424C4A1C1B88}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "uSync", "uSync", "{782F3EFF-9063-4C1D-AB3F-1E45734EFB27}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SeoToolkit.uSync", "SeoToolkit.uSync\SeoToolkit.uSync.csproj", "{3B981A49-B278-4D40-B8E2-EB62266FC80D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -123,6 +127,10 @@ Global
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B981A49-B278-4D40-B8E2-EB62266FC80D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B981A49-B278-4D40-B8E2-EB62266FC80D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B981A49-B278-4D40-B8E2-EB62266FC80D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B981A49-B278-4D40-B8E2-EB62266FC80D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,6 +148,7 @@ Global
 		{5B460335-8786-4FA9-911B-AEC5A752B88C} = {5641B436-FCCB-4D1A-9D25-6A39B95031CB}
 		{7C9ABE0D-106C-48C0-B0CF-DBBCD8AF334E} = {B0B49325-8248-4DB8-889D-211D9408D7A5}
 		{566D1DBF-EC21-405C-BB92-424C4A1C1B88} = {B0B49325-8248-4DB8-889D-211D9408D7A5}
+		{3B981A49-B278-4D40-B8E2-EB62266FC80D} = {782F3EFF-9063-4C1D-AB3F-1E45734EFB27}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {551ADBA5-3DFB-4300-929C-2BE0DB346636}

--- a/src/SeoToolkit.uSync/Composers/USyncComposer.cs
+++ b/src/SeoToolkit.uSync/Composers/USyncComposer.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using SeoToolkit.Umbraco.uSync.Core.XmlTrackers;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using uSync.Core.Tracking;
+
+namespace SeoToolkit.Umbraco.uSync.Core.Composers;
+
+public class USyncComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {
+
+        builder.Services.AddTransient<MetaFieldValuesSerializer, MetaFieldValuesSerializer>();
+        builder.Services.AddTransient<MetaFieldSettingsSerializer, MetaFieldSettingsSerializer>();
+        builder.Services.AddTransient<ISyncTrackerBase, SeoToolkitXmlTracker>();
+    }
+}

--- a/src/SeoToolkit.uSync/Constants/Serialization.cs
+++ b/src/SeoToolkit.uSync/Constants/Serialization.cs
@@ -1,0 +1,9 @@
+﻿namespace SeoToolkit.Umbraco.uSync.Core.Constants;
+
+public static class Serialization
+{
+    public const string DocumentTypeSettingsDto = "DocumentTypeSettingsDto";
+    public const string MetaFieldValues = "MetaFieldValues";
+    
+    public const string RootName = "Content";
+}

--- a/src/SeoToolkit.uSync/Handlers/MetaFieldSettingsHandler.cs
+++ b/src/SeoToolkit.uSync/Handlers/MetaFieldSettingsHandler.cs
@@ -1,0 +1,52 @@
+﻿using SeoToolkit.Umbraco.MetaFields.Core.Models.DocumentTypeSettings.Business;
+using uSync.BackOffice;
+
+
+using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.Common.Core.Interfaces;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Strings;
+
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.BackOffice.SyncHandlers;
+using uSync.Core;
+using uSyncConstants = uSync.BackOffice.uSyncConstants;
+
+namespace SeoToolkit.uSync.Handlers
+{
+    [SyncHandler("seoToolkitTest", "seoToolkit DocTypes", "seoToolkitContentTypes", uSyncConstants.Priorites.ContentTypes,
+        IsTwoPass = true, Icon = "icon-item-arrangement", EntityType = Constants.UdiEntityType.DocumentType)]
+    public class MetaFieldSettingsHandler : SeoToolKitSyncHandlerBase<DocumentTypeSettingsDto>, ISyncHandler
+    {
+        private readonly IRepository<DocumentTypeSettingsDto> _repository;
+
+        //TODO should ideally be implemented
+        protected override IEnumerable<uSyncAction> DeleteMissingItems(DocumentTypeSettingsDto parent, IEnumerable<Guid> keysToKeep, bool reportOnly)
+        {
+            return new List<uSyncAction>();
+        }
+        
+
+        protected override IEnumerable<DocumentTypeSettingsDto> GetChildItems(DocumentTypeSettingsDto parent)
+        {
+            return parent == null! ? _repository.GetAll().ToList() : new List<DocumentTypeSettingsDto>();
+        }
+
+        protected override string GetItemName(DocumentTypeSettingsDto item)
+        {
+            return item.Content.Name ?? "";
+        }
+
+        public IEnumerable<uSyncAction> ProcessPostImport(string folder, IEnumerable<uSyncAction> actions, HandlerSettings config)
+        {
+            return new List<uSyncAction>();
+        }
+
+        public MetaFieldSettingsHandler(IRepository<DocumentTypeSettingsDto> repository, ILogger<MetaFieldSettingsHandler> logger, AppCaches appCaches, IShortStringHelper shortStringHelper, SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfig, ISyncItemFactory itemFactory) : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+        {
+            _repository = repository;
+        }
+    }
+}

--- a/src/SeoToolkit.uSync/Handlers/MetaFieldValuesHandler.cs
+++ b/src/SeoToolkit.uSync/Handlers/MetaFieldValuesHandler.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoSettings.Database;
+using SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Strings;
+using uSync.BackOffice;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.BackOffice.SyncHandlers;
+using uSync.Core;
+using uSyncConstants = uSync.BackOffice.uSyncConstants;
+
+namespace SeoToolkit.uSync.Handlers;
+
+[SyncHandler("seoToolkitMetaFieldValuesHandler", "SeoToolkit Meta Fields", "SeoToolkitMetaFields", uSyncConstants.Priorites.Content
+    , Icon = "icon-list", IsTwoPass = false, EntityType = Constants.UdiEntityType.Document)]
+public class MetaFieldValuesHandler : SeoToolKitSyncHandlerBase<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>, ISyncHandler
+{
+    private readonly IMetaFieldsValueRepository _metaFieldsValueRepository;
+
+    public MetaFieldValuesHandler(IMetaFieldsValueRepository metaFieldsValueRepository, ILogger<MetaFieldValuesHandler> logger, AppCaches appCaches, IShortStringHelper shortStringHelper, SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfig, ISyncItemFactory itemFactory) : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+    {
+        this.ItemType = "SeoToolkit Meta";
+        _metaFieldsValueRepository = metaFieldsValueRepository;
+    }
+
+    //TODO this should ideally be implemented
+    protected override IEnumerable<uSyncAction> DeleteMissingItems(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? parent, IEnumerable<Guid> keysToKeep, bool reportOnly)
+    {
+        return new List<uSyncAction>();
+    }
+    
+    public IEnumerable<uSyncAction> ProcessPostImport(string folder, IEnumerable<uSyncAction> actions, HandlerSettings config)
+    {
+        return new List<uSyncAction>();
+    }
+
+    protected override IEnumerable<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?> GetChildItems(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? parent)
+    {
+        if (parent != null!) return new List<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>();
+        var allField = _metaFieldsValueRepository.GetAll().Select(metaFieldGroup =>
+        {
+            KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? kv = new KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>(metaFieldGroup.Key, metaFieldGroup.ToList());
+            return kv;
+        });
+        return allField;
+    }
+
+    protected override string GetItemName(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        if (item == null)
+            return "";
+        return item.Value.Key.ToString();
+    }
+    
+}

--- a/src/SeoToolkit.uSync/Handlers/SeoToolKitSyncHandlerBase.cs
+++ b/src/SeoToolkit.uSync/Handlers/SeoToolKitSyncHandlerBase.cs
@@ -1,0 +1,32 @@
+﻿using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Cache;
+using Umbraco.Cms.Core.Strings;
+using uSync.BackOffice.Configuration;
+using uSync.BackOffice.Services;
+using uSync.BackOffice.SyncHandlers;
+using uSync.Core;
+
+
+namespace SeoToolkit.uSync.Handlers;
+public abstract class SeoToolKitSyncHandlerBase<TObject> : SyncHandlerRoot<TObject, TObject>
+{
+    protected override IEnumerable<TObject> GetFolders(TObject parent)
+        => Enumerable.Empty<TObject>();
+    protected override TObject GetFromService(TObject item)
+        => item;
+
+    protected override bool ShouldImport(XElement node, HandlerSettings config)
+    {
+        return base.ShouldImport(node, config);
+    }
+
+    protected override bool ShouldExport(XElement node, HandlerSettings config)
+    {
+        return base.ShouldExport(node, config);
+    }
+
+    protected SeoToolKitSyncHandlerBase(ILogger<SeoToolKitSyncHandlerBase<TObject>> logger, AppCaches appCaches, IShortStringHelper shortStringHelper, SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfig, ISyncItemFactory itemFactory) : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+    {
+    }
+}

--- a/src/SeoToolkit.uSync/Handlers/SeoToolKitSyncHandlerBase.cs
+++ b/src/SeoToolkit.uSync/Handlers/SeoToolKitSyncHandlerBase.cs
@@ -11,6 +11,12 @@ using uSync.Core;
 namespace SeoToolkit.uSync.Handlers;
 public abstract class SeoToolKitSyncHandlerBase<TObject> : SyncHandlerRoot<TObject, TObject>
 {
+    public override string Group => "SeoToolkit";
+
+    protected SeoToolKitSyncHandlerBase(ILogger<SyncHandlerRoot<TObject, TObject>> logger, AppCaches appCaches, IShortStringHelper shortStringHelper, SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfig, ISyncItemFactory itemFactory) : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
+    {
+    }
+
     protected override IEnumerable<TObject> GetFolders(TObject parent)
         => Enumerable.Empty<TObject>();
     protected override TObject GetFromService(TObject item)
@@ -24,9 +30,5 @@ public abstract class SeoToolKitSyncHandlerBase<TObject> : SyncHandlerRoot<TObje
     protected override bool ShouldExport(XElement node, HandlerSettings config)
     {
         return base.ShouldExport(node, config);
-    }
-
-    protected SeoToolKitSyncHandlerBase(ILogger<SeoToolKitSyncHandlerBase<TObject>> logger, AppCaches appCaches, IShortStringHelper shortStringHelper, SyncFileService syncFileService, uSyncEventService mutexService, uSyncConfigService uSyncConfig, ISyncItemFactory itemFactory) : base(logger, appCaches, shortStringHelper, syncFileService, mutexService, uSyncConfig, itemFactory)
-    {
     }
 }

--- a/src/SeoToolkit.uSync/SeoToolkit.uSync.csproj
+++ b/src/SeoToolkit.uSync/SeoToolkit.uSync.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Umbraco.Cms.Core" Version="11.0.0" />
+      <PackageReference Include="uSync.BackOffice" Version="11.0.2" />
+      <PackageReference Include="uSync.Core" Version="11.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\SeoToolkit.Umbraco.MetaFields.Core\SeoToolkit.Umbraco.MetaFields.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/SeoToolkit.uSync/Serializers/MetaFieldSettingsSerializer.cs
+++ b/src/SeoToolkit.uSync/Serializers/MetaFieldSettingsSerializer.cs
@@ -1,0 +1,150 @@
+﻿using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.Common.Core.Interfaces;
+using SeoToolkit.Umbraco.MetaFields.Core.Constants;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.SeoField;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.Converters;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.DocumentTypeSettings.Business;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoField;
+using SeoToolkit.Umbraco.MetaFields.Core.Services.DocumentTypeSettings;
+using Umbraco.Cms.Core.Web;
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+
+namespace SeoToolkit.Umbraco.uSync.Core.Serializers;
+
+[SyncSerializer("dce705fa-7259-4754-8d6b-1eeeb05f5f12", "SeoToolkit.MetaFieldSerializer",
+    Constants.Serialization.MetaFieldValues)]
+public class MetaFieldSettingsSerializer : SyncSerializerRoot<DocumentTypeSettingsDto>, ISyncSerializer<DocumentTypeSettingsDto>
+{
+    private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly IRepository<DocumentTypeSettingsDto> _repository;
+    private readonly IMetaFieldsSettingsService _metaFieldsSettingsService;
+
+    public MetaFieldSettingsSerializer(IMetaFieldsSettingsService metaFieldsSettingsService,
+        IUmbracoContextFactory umbracoContextFactory, ILogger<MetaFieldSettingsSerializer> logger,
+        IRepository<DocumentTypeSettingsDto> repository) : base(logger)
+    {
+        _metaFieldsSettingsService = metaFieldsSettingsService;
+        _umbracoContextFactory = umbracoContextFactory;
+        _repository = repository;
+    }
+
+    private const string Value = "Value";
+    private const string Fields = "Fields";
+    private const string Editor = "Editor";
+    private const string EditEditor = "EditEditor";
+    private const string SeoField = "SeoField";
+
+    protected override SyncAttempt<XElement> SerializeCore(DocumentTypeSettingsDto item, SyncSerializerOptions options)
+    {
+        var node = InitializeNode(item);
+
+        var settingsDto = _repository.Get(item.Content.Id);
+
+        if (settingsDto != null)
+        {
+            foreach (var el in from field in settingsDto.Fields let value = JsonSerializer.Serialize(field.Value) let editor = JsonSerializer.Serialize(field.Key.Editor) let editEditor = JsonSerializer.Serialize(field.Key.EditEditor) select new XElement(field.Key.Alias,
+                         new XElement(SeoField, field.Key.Alias),
+                         new XElement(Value, value),
+                         new XElement(Editor, editor),
+                         new XElement(EditEditor, editEditor)))
+            {
+                node.Add(el);
+            }
+        }
+        else
+        {
+            return SyncAttempt<XElement>.Succeed(item.Content.Name, node, typeof(DocumentTypeSettingsDto),
+                ChangeType.NoChange);
+        }
+
+
+        return SyncAttempt<XElement>.Succeed(item.Content.Name, node, typeof(DocumentTypeSettingsDto),
+            ChangeType.Export);
+    }
+
+
+    private XElement InitializeNode(DocumentTypeSettingsDto item)
+    {
+        return new XElement(Constants.Serialization.RootName, new XAttribute("Key", ItemKey(item)));
+    }
+
+    protected override SyncAttempt<DocumentTypeSettingsDto> DeserializeCore(XElement node,
+        SyncSerializerOptions options)
+    {
+        var attempt = FindItem(node);
+
+        attempt.Fields = node.Elements().Select(element =>
+        {
+            var seoFieldAlias = element.Element(SeoField)?.Value;
+            var valueJson = element.Element(Value)?.Value;
+            if (seoFieldAlias == null || valueJson == null) return new KeyValuePair<ISeoField, DocumentTypeValueDto>();
+            ISeoField field = seoFieldAlias switch
+            {
+                SeoFieldAliasConstants.Title => new SeoTitleField(),
+                SeoFieldAliasConstants.CanonicalUrl => new CanonicalUrlField(),
+                SeoFieldAliasConstants.MetaDescription => new SeoDescriptionField(),
+                SeoFieldAliasConstants.OpenGraphDescription => new OpenGraphDescriptionField(),
+                SeoFieldAliasConstants.OpenGraphImage => new OpenGraphImageField(_umbracoContextFactory),
+                SeoFieldAliasConstants.OpenGraphTitle => new OpenGraphTitleField(),
+                _ => new CanonicalUrlField()
+            };
+
+            var value = JsonSerializer.Deserialize<DocumentTypeValueDto>(valueJson);
+            if (value?.Value != null && seoFieldAlias != SeoFieldAliasConstants.CanonicalUrl)
+                value.Value = JsonSerializer.Deserialize<FieldsModel>(value.Value?.ToString()!);
+
+            return new KeyValuePair<ISeoField, DocumentTypeValueDto>(field, value!);
+
+        }).ToDictionary(x => x.Key, x => x.Value);
+
+
+        return SyncAttempt<DocumentTypeSettingsDto>.Succeed(node.GetAlias(), attempt,
+            typeof(DocumentTypeSettingsDto), ChangeType.Import);
+    }
+
+    public override bool IsValid(XElement node)
+    {
+        return true;
+    }
+
+    public override DocumentTypeSettingsDto FindItem(int id)
+    {
+        return _repository.Get(id);
+    }
+
+    public override DocumentTypeSettingsDto FindItem(Guid key)
+    {
+        return _repository.GetAll().FirstOrDefault(setting => setting.Content.Key == key)!;
+    }
+
+    public override DocumentTypeSettingsDto FindItem(string alias)
+    {
+        return _repository.GetAll().FirstOrDefault(setting => setting.Content.Alias == alias)!;
+    }
+
+
+    public override void SaveItem(DocumentTypeSettingsDto item)
+    {
+        _metaFieldsSettingsService.Set(item);
+    }
+
+    //TODO implement this
+    public override void DeleteItem(DocumentTypeSettingsDto item)
+    {
+        _repository.Delete(item.Content.Id);
+    }
+
+    public override string ItemAlias(DocumentTypeSettingsDto item)
+    {
+        return item.Content.Alias;
+    }
+
+    public override Guid ItemKey(DocumentTypeSettingsDto item)
+    {
+        return item.Content.Key;
+    }
+}

--- a/src/SeoToolkit.uSync/Serializers/MetaFieldValuesSerializer.cs
+++ b/src/SeoToolkit.uSync/Serializers/MetaFieldValuesSerializer.cs
@@ -1,0 +1,228 @@
+﻿using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using SeoToolkit.Umbraco.MetaFields.Core.Interfaces.Services;
+using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoSettings.Database;
+using SeoToolkit.Umbraco.MetaFields.Core.Repositories.SeoValueRepository;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Services;
+using uSync.Core;
+using uSync.Core.Models;
+using uSync.Core.Serialization;
+
+namespace SeoToolkit.Umbraco.uSync.Core.Serializers;
+
+[SyncSerializer("cfeaa2d0-8af5-4ef4-9dd6-3b696df18189", "SeoToolkit.MetaFieldSerializer",
+    Constants.Serialization.MetaFieldValues)]
+public class MetaFieldValuesSerializer : SyncSerializerRoot<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>, ISyncSerializer<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>
+{
+    private readonly IMetaFieldsValueRepository _metaFieldsValueRepository;
+    private readonly IMetaFieldsValueService _metaFieldsValueService;
+    private readonly IContentService _contentService;
+    private readonly ILocalizationService _localizationService;
+    
+
+    
+    public MetaFieldValuesSerializer(IMetaFieldsValueService metaFieldsValueService,  IMetaFieldsValueRepository metaFieldsValueRepository,IContentService contentService ,ILocalizationService localizationService ,ILogger<MetaFieldValuesSerializer> logger) : base(logger)
+    {
+        _metaFieldsValueService = metaFieldsValueService;
+        _metaFieldsValueRepository = metaFieldsValueRepository;
+        _contentService = contentService;
+        _localizationService = localizationService;
+    }
+
+    static Dictionary<string,object?> MetaFieldsValueEntitiesToDictionary(IEnumerable<MetaFieldsValueEntity> items, string culture)
+    {
+        return items.Where(it => it.Culture == culture).ToDictionary(it => it.Alias, it =>(object?)it.UserValue);
+    }
+    
+
+    private XElement InitializeNode(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        return new XElement(Constants.Serialization.RootName, new XAttribute("Key", ItemKey(item)),
+            new XAttribute("Alias", ItemAlias(item)));
+    }
+    
+    private const string Value = "Value";
+    private const string Culture = "Culture";
+    protected override SyncAttempt<XElement> SerializeCore(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item, SyncSerializerOptions options)
+    {
+        var node = InitializeNode(item);
+
+        var languageVariants = _localizationService.GetAllLanguages();
+
+        if(item == null)
+            return SyncAttempt<XElement>.Fail("NaN", ChangeType.NoChange, "No Meta Fields");
+        
+        foreach (var languageVariant in languageVariants)
+        {
+            var fields = MetaFieldsValueEntitiesToDictionary(item.Value.Value, languageVariant.IsoCode);
+
+            if (!fields.Any())
+            {
+                return SyncAttempt<XElement>.Fail(item.Value.Key.ToString(), ChangeType.NoChange, "No Meta Fields");
+            }
+
+            foreach (var field in fields)
+            {
+                var currentNode = node.Element(field.Key);
+                if (currentNode == null)
+                {
+                    var element = new XElement(field.Key, new XElement(Value, field.Value, new XAttribute(Culture, languageVariant.IsoCode)));
+                    node.Add(element);
+                }
+                else
+                {
+                    currentNode.Add(new XElement(Value, field.Value, new XAttribute(Culture, languageVariant.IsoCode)));
+                }
+       
+            }
+        }
+
+
+        return SyncAttempt<XElement>.Succeed(item.Value.Key.ToString(), node, typeof(IContent), ChangeType.Export);
+    }
+
+    protected override SyncAttempt<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?> CanDeserialize(XElement node, SyncSerializerOptions options)
+    {
+        return base.CanDeserialize(node, options);
+    }
+
+    protected override SyncAttempt<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?> DeserializeCore(XElement node, SyncSerializerOptions options)
+    {
+        var id = GetId(node);
+        var list = new List<MetaFieldsValueEntity>();
+        KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? kv = new KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>(id, list);
+        var lookup = new Dictionary<string, Dictionary<string,string>>();
+
+        var currentNode = node.FirstNode as XElement;
+        while (currentNode != null)
+        {
+            if (lookup.TryGetValue(currentNode!.Name.LocalName, out var fieldsDictionary))
+            {
+                foreach (var nodeValue in currentNode.Nodes())
+                {
+                    var elementValue = nodeValue as XElement;
+                    if(elementValue == null)
+                        continue;
+                    fieldsDictionary.Add(elementValue.FirstAttribute!.Value, elementValue.Value);
+                }
+            }
+            else
+            {
+                var tempKvList = new Dictionary<string, string>();
+                foreach (var nodeValue in currentNode.Nodes())
+                {
+                    var elementValue = nodeValue as XElement;
+                    if(elementValue == null)
+                        continue;
+                    tempKvList.Add(elementValue.FirstAttribute!.Value, elementValue.Value);
+                }
+                lookup.Add(currentNode!.Name.LocalName, tempKvList);
+            }
+            currentNode = currentNode.NextNode as XElement;
+        }
+
+        var first = lookup.FirstOrDefault().Value.ToList();
+        for (int i = 0; i < first.Count; i++)
+        {
+            var culture = first[i].Key;
+            foreach (var keyValuePair in lookup)
+            {
+                var entity = new MetaFieldsValueEntity()
+                {
+                    Alias = keyValuePair.Key,
+                    NodeId = id,
+                    UserValue = keyValuePair.Value[culture],
+                    Culture = culture
+                };
+                list.Add(entity);
+            }
+        }
+
+
+
+        return SyncAttempt<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>.Succeed(node.GetAlias(), kv,
+            typeof(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?), ChangeType.Import);
+        
+
+    }
+
+    private const string Alias = "Alias";
+
+    public static int GetId(XElement node)
+    {
+        if (int.TryParse(node.Attribute(Alias)?.Value, out var id))
+        {
+            return id;
+        }
+
+        return -1;
+    }
+
+    public override KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? FindItem(int id)
+    {
+        var value = _metaFieldsValueRepository.GetAll().Where(it => it.Key == id).SelectMany(it => it);
+        return new KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>(id, value);
+    }
+
+    public override KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? FindItem(Guid key)
+    {
+        var content = _contentService.GetById(key);
+        if (content == null)
+            return null!;
+        return FindItem(content.Id);
+    }
+
+    public override KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? FindItem(string alias)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override void SaveItem(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        if(item == null)
+            return;
+        var id = item.Value.Key;
+        foreach (var group in item.Value.Value.GroupBy(it => it.Culture))
+        {
+            var culture = group.Key;
+            var values = MetaFieldsValueEntitiesToDictionary(group.ToList(), culture);
+            _metaFieldsValueService.AddValues(id, values, culture);
+        }
+        
+    }
+
+    public override void DeleteItem(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        if(item == null)
+            return;
+        var id = item.Value.Key;
+        foreach (var group in item.Value.Value.GroupBy(it => it.Culture))
+        {
+            var culture = group.Key;
+            var aliases = MetaFieldsValueEntitiesToDictionary(group.ToList(), culture).Select(metaField => metaField.Key );
+            foreach (var alias in aliases)
+            {
+                _metaFieldsValueService.Delete(id, alias, culture);
+            }
+        }
+    }
+    public override bool IsValid(XElement node)
+    {
+        return true;
+    }
+    public override string ItemAlias(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        if(item == null)
+            return "";
+        return item.Value.Key.ToString();
+    }
+
+    public override Guid ItemKey(KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>? item)
+    {
+        if(item == null)
+            return Guid.Empty;
+        var content = _contentService.GetById(item.Value.Key);
+        return content?.Key ?? Guid.Empty;
+    }
+}

--- a/src/SeoToolkit.uSync/XmlTrackers/SeoToolkitXmlTracker.cs
+++ b/src/SeoToolkit.uSync/XmlTrackers/SeoToolkitXmlTracker.cs
@@ -1,0 +1,24 @@
+﻿using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoSettings.Database;
+using SeoToolkit.Umbraco.uSync.Core.Serializers;
+using uSync.Core.Serialization;
+using uSync.Core.Tracking;
+
+namespace SeoToolkit.Umbraco.uSync.Core.XmlTrackers;
+
+public class SeoToolkitXmlTracker :
+    SyncXmlTracker<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>,
+    ISyncTracker<KeyValuePair<int, IEnumerable<MetaFieldsValueEntity>>?>
+{
+    public override List<TrackingItem> TrackingItems => new List<TrackingItem>()
+    {
+        TrackingItem.Many("Property - *", "/*/Value", "@Culture"),
+
+    };
+
+    public SeoToolkitXmlTracker(SyncSerializerCollection serializers, MetaFieldValuesSerializer serializer) : base(serializers)
+    {
+        this.serializer = serializer;
+    }
+
+   
+}


### PR DESCRIPTION
The initial draft for uSync implementation. 

- [x] Sync meta field- / SEO field values
- [x]  Support language variants

- [x] Sync SEO settings

For now both handlers are under settings in the uSync dashboard.. not sure why.
Events could be added in the respective services to trigger uSync if it's configured to  automatically export on updates. But I think this is out of scope for now.

Data in the database doesn't change when disabling SEO settings on a document-type. So not sure how to check for that type of change.