### PR TITLE
Add content to MetaTagsNotification objects

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Notifications/AfterMetaTagsNotification.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Notifications/AfterMetaTagsNotification.cs
@@ -1,4 +1,6 @@
 ﻿using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoService;
+using System;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Notifications;
 
 namespace SeoToolkit.Umbraco.MetaFields.Core.Notifications
@@ -7,10 +9,19 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Notifications
     {
         public string ContentTypeAlias { get; }
         public MetaTagsModel MetaTags { get; }
+        public IPublishedContent Content { get; set; }
 
+        [Obsolete("This constructor is deprecated and will be removed in the next major release.")]
         public AfterMetaTagsNotification(string contentTypeAlias, MetaTagsModel metaTags)
         {
             ContentTypeAlias = contentTypeAlias;
+            MetaTags = metaTags;
+        }
+
+        public AfterMetaTagsNotification(IPublishedContent content, MetaTagsModel metaTags)
+        {
+            Content = content;
+            ContentTypeAlias = content.ContentType.Alias;
             MetaTags = metaTags;
         }
     }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Notifications/BeforeMetaTagsNotification.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Notifications/BeforeMetaTagsNotification.cs
@@ -1,4 +1,6 @@
 ﻿using SeoToolkit.Umbraco.MetaFields.Core.Models.SeoService;
+using System;
+using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.Notifications;
 
 namespace SeoToolkit.Umbraco.MetaFields.Core.Notifications
@@ -7,10 +9,19 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Notifications
     {
         public string ContentTypeAlias { get; }
         public MetaTagsModel MetaTags { get; }
+        public IPublishedContent Content { get; set; }
 
+        [Obsolete("This constructor is deprecated and will be removed in the next major release.")]
         public BeforeMetaTagsNotification(string contentTypeAlias, MetaTagsModel metaTags)
         {
             ContentTypeAlias = contentTypeAlias;
+            MetaTags = metaTags;
+        }
+
+        public BeforeMetaTagsNotification(IPublishedContent content, MetaTagsModel metaTags)
+        {
+            Content = content;
+            ContentTypeAlias = content.ContentType.Alias;
             MetaTags = metaTags;
         }
     }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Providers/DefaultMetaTagsProvider.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Providers/DefaultMetaTagsProvider.cs
@@ -57,7 +57,7 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Providers
 
                 //Make sure that the fields are set, otherwise the values cannot be set!
                 var metaTags = new MetaTagsModel(allFields.ToDictionary(it => it, it => (object)null));
-                _eventAggregator.Publish(new BeforeMetaTagsNotification(content.ContentType.Alias, metaTags));
+                _eventAggregator.Publish(new BeforeMetaTagsNotification(content, metaTags));
 
                 var settings = _documentTypeSettingsService.Get(content.ContentType.Id);
                 if (settings is null)
@@ -113,7 +113,7 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Providers
                     metaTags.SetValue(fieldValue.Field.Alias, fieldValue.Value);
                 }
 
-                _eventAggregator.Publish(new AfterMetaTagsNotification(content.ContentType.Alias, metaTags));
+                _eventAggregator.Publish(new AfterMetaTagsNotification(content, metaTags));
 
                 return metaTags;
             }


### PR DESCRIPTION
Fixes #193

Ideally I would have removed the original `(string contentTypeAlias, MetaTagsModel metaTags)` constructors, but I kept them for strict backwards compatibility.  I struggle to imagine a scenario where end-users are creating these classes themselves, but they are public, and it is possible.

Again, this was based `dev/Umbraco10`