### PR TITLE
Add property to access metatags robots

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoService/MetaTagsModel.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoService/MetaTagsModel.cs
@@ -72,5 +72,11 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Models.SeoService
             get => GetValue<string>(SeoFieldAliasConstants.CanonicalUrl);
             set => SetValue(SeoFieldAliasConstants.CanonicalUrl, value);
         }
+
+        public string[] Robots
+        {
+            get => GetValue<string[]>(SeoFieldAliasConstants.Robots);
+            set => SetValue(SeoFieldAliasConstants.Robots, value);
+        }
     }
 }


### PR DESCRIPTION
Fixes #195

Add property to access Robots metadata in the `MetaTagsModel`