### PR TITLE
Add tree group to constants

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Constants/TreeControllerConstants.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Constants/TreeControllerConstants.cs
@@ -3,5 +3,6 @@
     public class TreeControllerConstants
     {
         public const string SeoToolkitTreeControllerAlias = "SiteAudit";
+        public const string SeoToolkitTreeGroupAlias = "SeoToolkit";
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Controllers/InfoTreeController.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Controllers/InfoTreeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SeoToolkit.Umbraco.Common.Core.Constants;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
@@ -9,9 +10,11 @@ using Umbraco.Cms.Web.BackOffice.Trees;
 namespace SeoToolkit.Umbraco.Common.Core.Controllers
 {
     //This controller is only here to prevent single node trees if you only download one package
-    [Tree("SeoToolkit", "info", TreeTitle = "Info", TreeGroup = "SeoToolkit", SortOrder = 99)]
+    [Tree("SeoToolkit", "info", TreeTitle = "Info", TreeGroup = TreeGroupAlias, SortOrder = 99)]
     public class InfoTreeController : TreeController
     {
+        public const string TreeGroupAlias = TreeControllerConstants.SeoToolkitTreeGroupAlias;
+
         public InfoTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IEventAggregator eventAggregator) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
         {
         }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsTreeController.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsTreeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SeoToolkit.Umbraco.Common.Core.Constants;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
@@ -9,10 +10,12 @@ using Umbraco.Cms.Web.Common.Attributes;
 
 namespace SeoToolkit.Umbraco.Redirects.Core.Controllers
 {
-    [Tree("SeoToolkit", "Redirects", TreeTitle = "Redirects", TreeGroup = "SeoToolkit", SortOrder = 4)]
+    [Tree("SeoToolkit", "Redirects", TreeTitle = "Redirects", TreeGroup = TreeGroupAlias, SortOrder = 4)]
     [PluginController("SeoToolkit")]
     public class RedirectsTreeController : TreeController
     {
+        public const string TreeGroupAlias = TreeControllerConstants.SeoToolkitTreeGroupAlias;
+
         public RedirectsTreeController(ILocalizedTextService localizedTextService, UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection, IEventAggregator eventAggregator) : base(localizedTextService, umbracoApiControllerTypeCollection, eventAggregator)
         {
         }

--- a/src/SeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtTreeController.cs
+++ b/src/SeoToolkit.Umbraco.RobotsTxt.Core/Controllers/RobotsTxtTreeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SeoToolkit.Umbraco.Common.Core.Constants;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Events;
 using Umbraco.Cms.Core.Services;
@@ -9,10 +10,12 @@ using Umbraco.Cms.Web.Common.Attributes;
 
 namespace SeoToolkit.Umbraco.RobotsTxt.Core.Controllers
 {
-    [Tree("SeoToolkit", "RobotsTxt", TreeTitle = "Robots.txt", TreeGroup = "SeoToolkit", SortOrder = 3)]
+    [Tree("SeoToolkit", "RobotsTxt", TreeTitle = "Robots.txt", TreeGroup = TreeGroupAlias, SortOrder = 3)]
     [PluginController("SeoToolkit")]
     public class RobotsTxtTreeController : TreeController
     {
+        public const string TreeGroupAlias = TreeControllerConstants.SeoToolkitTreeGroupAlias;
+
         public RobotsTxtTreeController(
             ILocalizedTextService localizedTextService,
             UmbracoApiControllerTypeCollection umbracoApiControllerTypeCollection,

--- a/src/SeoToolkit.Umbraco.ScriptManager.Core/Controllers/ScriptManagerTreeController.cs
+++ b/src/SeoToolkit.Umbraco.ScriptManager.Core/Controllers/ScriptManagerTreeController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using NUglify.JavaScript.Syntax;
+using SeoToolkit.Umbraco.Common.Core.Constants;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Events;
@@ -12,10 +13,12 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace SeoToolkit.Umbraco.ScriptManager.Core.Controllers
 {
-    [Tree("SeoToolkit", "ScriptManager", TreeTitle = "Script Manager", TreeGroup = "SeoToolkit", SortOrder = 2)]
+    [Tree("SeoToolkit", "ScriptManager", TreeTitle = "Script Manager", TreeGroup = TreeGroupAlias, SortOrder = 2)]
     [PluginController("SeoToolkit")]
     public class ScriptManagerTreeController : TreeController
     {
+        public const string TreeGroupAlias = TreeControllerConstants.SeoToolkitTreeGroupAlias;
+
         private readonly IMenuItemCollectionFactory _menuItemCollectionFactory;
 
         public ScriptManagerTreeController(

--- a/src/SeoToolkit.Umbraco.SiteAudit.Core/Controllers/SiteAuditTreeController.cs
+++ b/src/SeoToolkit.Umbraco.SiteAudit.Core/Controllers/SiteAuditTreeController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SeoToolkit.Umbraco.Common.Core.Constants;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Actions;
 using Umbraco.Cms.Core.Events;
@@ -12,10 +13,12 @@ using UmbConstants = Umbraco.Cms.Core.Constants;
 
 namespace SeoToolkit.Umbraco.SiteAudit.Core.Controllers
 {
-    [Tree("SeoToolkit", "SiteAudit", TreeTitle = "Site Audits", TreeGroup = "SeoToolkit", SortOrder = 1)]
+    [Tree("SeoToolkit", "SiteAudit", TreeTitle = "Site Audits", TreeGroup = TreeGroupAlias, SortOrder = 1)]
     [PluginController("SeoToolkit")]
     public class SeoToolkitTreeController : TreeController
     {
+        public const string TreeGroupAlias = TreeControllerConstants.SeoToolkitTreeGroupAlias;
+
         private readonly IMenuItemCollectionFactory _menuItemCollectionFactory;
 
         public SeoToolkitTreeController(ILocalizedTextService localizedTextService,


### PR DESCRIPTION
@patrickdemooij9 We're considering an addition to one of our projects, specifically the inclusion of a 404 module to extend your package. To achieve this, we've developed a custom tree controller and integrated it into the same TreeGroup (the SeoToolkit TreeGroup). However, our current implementation involves the use of a hardcoded string, which we find somewhat precarious. If you decide to modify the alias of the tree group, our extension would cease to function. Therefore, we'd prefer to use a constant to ensure greater stability and compatibility. If you like the addition I can do this for the section alias as well.

Btw, as far as I know @ambertvu has plans to create a PR to this repo with the 404 extension 😄!