### PR TITLE
Allow Redirects to be disabled

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsController.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsController.cs
@@ -43,6 +43,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Controllers
             {
                 Id = postModel.Id,
                 CustomDomain = postModel.CustomDomain,
+                IsEnabled = postModel.IsEnabled,
                 IsRegex = postModel.IsRegex,
                 OldUrl = postModel.OldUrl,
                 NewUrl = postModel.NewUrl,
@@ -98,6 +99,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Controllers
                 return new RedirectListViewModel
                 {
                     Id = it.Id,
+                    IsEnabled = it.IsEnabled,
                     OldUrl = it.OldUrl.IfNullOrWhiteSpace("/"),
                     NewUrl = it.GetNewUrl(),
                     Domain = domain,

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/IsEnabledMigration.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/IsEnabledMigration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using SeoToolkit.Umbraco.Redirects.Core.Models.Database;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace SeoToolkit.Umbraco.Redirects.Core.Migrations
+{
+    internal class IsEnabledMigration : MigrationBase
+    {
+        public IsEnabledMigration(IMigrationContext context) : base(context)
+        {
+        }
+
+        protected override void Migrate()
+        {
+            if (!ColumnExists("SeoToolkitRedirects", "IsEnabled"))
+            {
+                Alter.Table("SeoToolkitRedirects").AddColumn("IsEnabled").AsBoolean().Nullable().Do();
+                Update.Table("SeoToolkitRedirects").Set(new { IsEnabled = true}).AllRows().Do();
+                Alter.Table("SeoToolkitRedirects").AlterColumn("IsEnabled").AsBoolean().NotNullable().Do();
+            }
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/RedirectsMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/RedirectsMigrationPlan.cs
@@ -12,6 +12,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Migrations
         {
             To<InitialRedirectsMigration>("state-1");
             To<CreatedByMigration>("state-2");
+            To<IsEnabledMigration>("state-3");
         }
     }
 }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/Business/Redirect.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/Business/Redirect.cs
@@ -12,6 +12,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.Business
     public class Redirect
     {
         public int Id { get; set; }
+        public bool IsEnabled { get; set; }
         public bool IsRegex { get; set; }
         public Domain Domain { get; set; }
         public string CustomDomain { get; set; }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/Database/RedirectEntity.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/Database/RedirectEntity.cs
@@ -23,6 +23,9 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.Database
         [Column("IsRegex")]
         public bool IsRegex { get; set; }
 
+        [Column("IsEnabled")]
+        public bool IsEnabled { get; set; }
+
         [Column("OldUrl")]
         public string OldUrl { get; set; }
 

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/PostModels/SaveRedirectPostModel.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/PostModels/SaveRedirectPostModel.cs
@@ -10,6 +10,8 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.PostModels
         
         public string CustomDomain { get; set; }
         
+        public bool IsEnabled { get; set; }
+
         public bool IsRegex { get; set; }
         
         public string OldUrl { get; set; }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/ViewModels/RedirectListViewModel.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/ViewModels/RedirectListViewModel.cs
@@ -5,6 +5,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.ViewModels
     public class RedirectListViewModel
     {
         public int Id { get; set; }
+        public bool IsEnabled { get; set; }
         public string Domain { get; set; }
         public string OldUrl { get; set; }
         public string NewUrl { get; set; }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/ViewModels/RedirectViewModel.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/ViewModels/RedirectViewModel.cs
@@ -11,6 +11,8 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.ViewModels
 
         public string CustomDomain { get; set; }
 
+        public bool IsEnabled { get; set; }
+
         public bool IsRegex { get; set; }
 
         public string OldUrl { get; set; }
@@ -28,6 +30,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Models.ViewModels
             Id = redirect.Id;
             Domain = redirect.Domain?.Id;
             CustomDomain = redirect.CustomDomain;
+            IsEnabled = redirect.IsEnabled;
             IsRegex = redirect.IsRegex;
             OldUrl = redirect.OldUrl.IfNullOrWhiteSpace("/");
             NewUrl = redirect.NewUrl;

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Repositories/RedirectsRepository.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Repositories/RedirectsRepository.cs
@@ -106,7 +106,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Repositories
                     return scope.Database.Fetch<RedirectEntity>(scope.SqlContext.Sql()
                             .SelectAll()
                             .From<RedirectEntity>()
-                            .Where<RedirectEntity>(it => it.IsRegex))
+                            .Where<RedirectEntity>(it => it.IsEnabled && it.IsRegex))
                         .Select(ToModel).ToArray();
                 }
             }, TimeSpan.FromMinutes(10));
@@ -119,7 +119,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Repositories
                 return scope.Database.Fetch<RedirectEntity>(scope.SqlContext.Sql()
                         .SelectAll()
                         .From<RedirectEntity>()
-                        .Where<RedirectEntity>(it => !it.IsRegex && paths.Contains(it.OldUrl)))
+                        .Where<RedirectEntity>(it => it.IsEnabled && !it.IsRegex && paths.Contains(it.OldUrl)))
                     .Select(ToModel);
             }
         }
@@ -132,6 +132,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Repositories
                 Domain = redirect.Domain?.Id,
                 CustomDomain = redirect.CustomDomain,
                 IsRegex = redirect.IsRegex,
+                IsEnabled = redirect.IsEnabled,
                 OldUrl = redirect.OldUrl,
                 NewNodeId = redirect.NewNode?.Id,
                 NewUrl = redirect.NewUrl,
@@ -153,6 +154,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Repositories
                         ? null
                         : ctx.UmbracoContext.Domains.GetAll(false).FirstOrDefault(it => it.Id == entity.Domain),
                     CustomDomain = entity.CustomDomain,
+                    IsEnabled = entity.IsEnabled,
                     IsRegex = entity.IsRegex,
                     OldUrl = entity.OldUrl,
                     NewNode = entity.NewNodeId is null

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/createRedirect.controller.js
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/createRedirect.controller.js
@@ -36,6 +36,14 @@
             }
         }
 
+        vm.isEnabledProperty = {
+            alias: "enabled",
+            label: "Enabled",
+            description: "Uncheck this box to stop the redirect from functioning",
+            value: "1",
+            view: "boolean"
+        }
+
         vm.oldUrlProperty = {
             alias: "oldUrl",
             label: "From Url",
@@ -87,6 +95,7 @@
                 } else {
                     vm.domainProperty.value = $scope.model.redirect.customDomain ? -1 : 0;
                 }
+                vm.isEnabledProperty.value = $scope.model.redirect.isEnabled ? '1' : '0';
                 vm.customDomainProperty.value = $scope.model.redirect.customDomain;
                 vm.oldUrlProperty.value = $scope.model.redirect.oldUrl;
                 vm.oldUrlType = $scope.model.redirect.isRegex ? 2 : 1;
@@ -131,6 +140,7 @@
                 $scope.model.submit({
                     id: vm.id,
                     domain: vm.domainProperty.value > 0 ? vm.domainProperty.value : null,
+                    isEnabled: vm.isEnabledProperty.value === '1',
                     customDomain: vm.domainProperty.value === -1 ? vm.customDomainProperty.value : null,
                     urlType: vm.oldUrlType,
                     oldUrl: vm.oldUrlProperty.value,

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/createRedirect.html
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/createRedirect.html
@@ -24,6 +24,11 @@
                         <umb-property property="vm.customDomainProperty" ng-show="vm.domainProperty.value === -1">
                             <umb-property-editor model="vm.customDomainProperty"></umb-property-editor>
                         </umb-property>
+                        <umb-property property="vm.isEnabledProperty">
+                            <div class="flex">
+                                <umb-property-editor model="vm.isEnabledProperty"></umb-property-editor>
+                            </div>
+                        </umb-property>
                         <umb-property property="vm.oldUrlProperty">
                             <div class="flex">
                                 <umb-property-editor model="vm.oldUrlProperty"></umb-property-editor>

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.controller.js
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.controller.js
@@ -110,6 +110,7 @@
                             domain: model.domain,
                             customDomain: model.customDomain,
                             isRegex: model.urlType === 2,
+                            isEnabled: model.isEnabled,
                             oldUrl: model.oldUrl,
                             newUrl: model.newUrl,
                             newNodeId: model.newNodeId,
@@ -149,6 +150,7 @@
                     customDomain: redirect.CustomDomain ?? "",
                     oldUrl: redirect.OldUrl,
                     isRegex: redirect.IsRegex,
+                    isEnabled: redirect.IsEnabled,
                     newUrl: redirect.NewUrl,
                     newNodeId: redirect.NewNodeId,
                     newCultureId: redirect.NewCultureId,
@@ -190,7 +192,8 @@
                                 : i.StatusCode === 302 ? 'Temporary (302)'
                             : undefined,
                     "lastUpdated": i.LastUpdated,
-                    "published": true
+                    "published": i.IsEnabled,
+                    "updater": '-'
                 }
             });
         }


### PR DESCRIPTION
This is from [i47](https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/47) and allows redirects to be disabled in the system rather than deleted.

A toggle has been added to the add/edit page that allows them to be enabled and disabled. If a redirect is enabled, it follows the redirect, if disabled it ignores it!

The toggle is 'enabled' by default (one less click when adding) and they are greyed out in the list if they aren't enabled.

![image](https://github.com/patrickdemooij9/SeoToolkit.Umbraco/assets/5808078/dc72b1cb-6165-4dd6-ab5e-376196ca2503)

My test cases were:
- Add a new redirect
- Edit an existing redirect
- Spawn up and install on a new Umbraco
- Run the previous version, and then upgrade to this package version (using migrations)
- Enable the redirect and go to the URL (URL based and regex based)
- Disable the redirect and go to the URL (URL based and regex based)

I do agree with the original issue that it might be nice to be able to do this by bulk from the list, but haven't completed it in the PR.