### PR TITLE
Fix regex redirect with custom domain

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
@@ -151,13 +151,18 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Services
 
                 var regexRedirects = _redirectsRepository.GetAllRegexRedirects().Where(it =>
                 {
-                    if (it.Domain == null) return true;
-                    if (domain != null && it.Domain.Id == domain.Id) return true;
-                    if (domain is null &&
-                        !string.IsNullOrWhiteSpace(it.CustomDomain) &&
+                    // Selected Any site
+                    if (it.Domain == null && string.IsNullOrWhiteSpace(it.CustomDomain)) return true;
+                    
+                    // Selected a domain
+                    if (it.Domain != null && domain != null && it.Domain.Id == domain.Id) return true;
+                    
+                    // Selected a Custom domain
+                    if (it.Domain == null && !string.IsNullOrWhiteSpace(it.CustomDomain) &&
                         (it.CustomDomain.Equals(customDomainWithoutScheme,
                              StringComparison.InvariantCultureIgnoreCase) ||
                          it.CustomDomain.Equals(customDomainWithScheme))) return true;
+
                     return false;
                 });
 

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
@@ -139,7 +139,7 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Services
                         //Else check if we can find a redirect on the custom domain
                         foundRedirect = redirects.FirstOrDefault(it => it.CustomDomain != null && (it.CustomDomain.Equals(customDomainWithoutScheme, StringComparison.InvariantCultureIgnoreCase) || it.CustomDomain.Equals(customDomainWithScheme)));
                         if (foundRedirect != null) return new RedirectFindResult(uri, foundRedirect);
-                    }                    
+                    }                 
 
                     //Else check if we can find a redirect on the global level
                     foundRedirect = redirects.FirstOrDefault(it =>
@@ -151,14 +151,14 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Services
 
                 var regexRedirects = _redirectsRepository.GetAllRegexRedirects().Where(it =>
                 {
-                    // Selected Any site
+                    // Any site
                     if (it.Domain == null && string.IsNullOrWhiteSpace(it.CustomDomain)) return true;
                     
-                    // Selected a domain
+                    // Find by domain
                     if (it.Domain != null && domain != null && it.Domain.Id == domain.Id) return true;
                     
-                    // Selected a Custom domain
-                    if (it.Domain == null && !string.IsNullOrWhiteSpace(it.CustomDomain) &&
+                    // Find by Custom domain
+                    if (!string.IsNullOrWhiteSpace(it.CustomDomain) &&
                         (it.CustomDomain.Equals(customDomainWithoutScheme,
                              StringComparison.InvariantCultureIgnoreCase) ||
                          it.CustomDomain.Equals(customDomainWithScheme))) return true;


### PR DESCRIPTION
When using regex redirect with a custom domain, it triggers on all domains instead of only the custom domain. This MR fixes this.