### PR TITLE
Facebook uses the property attribute for og:url and og:fb_appid

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/FacebookIdField.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/FacebookIdField.cs
@@ -28,6 +28,6 @@ public class FacebookIdField : SeoField<string>
 
     protected override HtmlString Render(string value)
     {
-        return new HtmlString(value.IsNullOrWhiteSpace() ? string.Empty : $"<meta name=\"fb:app_id\" content=\"{value}\"/>");
+        return new HtmlString(value.IsNullOrWhiteSpace() ? string.Empty : $"<meta property=\"fb:app_id\" content=\"{value}\"/>");
     }
 }

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/OpenGraphUrlField.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Models/SeoField/OpenGraphUrlField.cs
@@ -29,6 +29,6 @@ public class OpenGraphUrlField : SeoField<string>
 
     protected override HtmlString Render(string value)
     {
-        return new HtmlString(value.IsNullOrWhiteSpace() ? null : $"<meta name=\"og:url\" content=\"{value}\"/>");
+        return new HtmlString(value.IsNullOrWhiteSpace() ? null : $"<meta property=\"og:url\" content=\"{value}\"/>");
     }
 }


### PR DESCRIPTION
Facebook uses the property attribute in the meta tag for og:url and og:fb_appid, and does not use the name attribute.