### PR TITLE
Added import functionality for redirects module

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects.Core/Composers/RedirectsComposer.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Composers/RedirectsComposer.cs
@@ -8,12 +8,12 @@ using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Extensions;
 using SeoToolkit.Umbraco.Common.Core.Constants;
-using SeoToolkit.Umbraco.Common.Core.Extensions;
 using SeoToolkit.Umbraco.Common.Core.Services.SettingsService;
 using SeoToolkit.Umbraco.Redirects.Core.Components;
 using SeoToolkit.Umbraco.Redirects.Core.Config;
 using SeoToolkit.Umbraco.Redirects.Core.Config.Models;
 using SeoToolkit.Umbraco.Redirects.Core.Controllers;
+using SeoToolkit.Umbraco.Redirects.Core.Helpers;
 using SeoToolkit.Umbraco.Redirects.Core.Interfaces;
 using SeoToolkit.Umbraco.Redirects.Core.Middleware;
 using SeoToolkit.Umbraco.Redirects.Core.Repositories;
@@ -42,11 +42,12 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Composers
             {
                 builder.Trees().RemoveTreeController<RedirectsTreeController>();
             }
-            
+
             builder.Components().Append<EnableModuleComponent>();
 
             builder.Services.AddUnique<IRedirectsRepository, RedirectsRepository>();
             builder.Services.AddUnique<IRedirectsService, RedirectsService>();
+            builder.Services.AddTransient<RedirectsImportHelper>();
 
             if (!disabledModules.Contains(DisabledModuleConstant.Middleware))
             {

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Constants/ImportConstants.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Constants/ImportConstants.cs
@@ -1,0 +1,8 @@
+﻿namespace SeoToolkit.Umbraco.Redirects.Core.Constants;
+
+public class ImportConstants
+{
+    public const string SessionAlias = "uploadedImportRedirectsFile";
+    public const string SessionFileTypeAlias = "uploadedFileType";
+    public const string SessionDomainId = "selectedDomain";
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Enumerators/ImportRedirectsFileExtension.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Enumerators/ImportRedirectsFileExtension.cs
@@ -1,0 +1,7 @@
+﻿namespace SeoToolkit.Umbraco.Redirects.Core.Enumerators;
+
+public enum ImportRedirectsFileExtension
+{
+    Csv,
+    Excel
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Microsoft.VisualBasic.FileIO;
+using SeoToolkit.Umbraco.Redirects.Core.Interfaces;
+using SeoToolkit.Umbraco.Redirects.Core.Models.Business;
+using Umbraco.Cms.Core.Routing;
+using Umbraco.Cms.Core.Web;
+
+namespace SeoToolkit.Umbraco.Redirects.Core.Helpers;
+
+public class RedirectsImportHelper
+{
+    private Domain _selectedDomain;
+    private readonly IRedirectsService _redirectsService;
+    private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+    public RedirectsImportHelper(IRedirectsService redirectsService, IUmbracoContextFactory umbracoContextFactory)
+    {
+        _redirectsService = redirectsService;
+        _umbracoContextFactory = umbracoContextFactory;
+    }
+
+    public  HttpResponseMessage ImportCsv(Stream fileStream, bool importFile, string domain)
+    {
+        SetDomain(domain);
+        //This currently assumes no header, and only 2 columns, from and to url
+        fileStream.Position = 0;
+        using (var reader = new StreamReader(fileStream))
+        using (var parser = new TextFieldParser(reader))
+        {
+            parser.TextFieldType = FieldType.Delimited;
+            parser.SetDelimiters(",");
+            var parsedData = new Dictionary<string,string>(); 
+            
+            while (!parser.EndOfData)
+            {
+                var fields = parser.ReadFields();
+                if (fields?.Length != 2)
+                {
+                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Validation failed: only 2 columns allowed on line {parser.LineNumber}" };
+                }
+                
+                if(!string.IsNullOrWhiteSpace(fields[0]) && !string.IsNullOrWhiteSpace(fields[1])){
+                    
+                    if(UrlExists(fields[0]))
+                    {
+                        return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Redirect already exists for 'from' URL: {fields[0]} validation aborted." };
+                    }
+                    parsedData.Add(fields[0], fields[1]);
+                    
+                }
+                else
+                {
+                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"line {parser.LineNumber}" };
+                }
+            }
+
+            if (importFile)
+            {
+                foreach (var entry in parsedData)
+                {
+                    this.SaveRedirect(entry);
+                }
+            }
+        }
+
+        return new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
+    }
+    
+    private bool UrlExists(string oldUrl)
+    {
+        var existingRedirects = _redirectsService.GetAll(1, 10, null, null, oldUrl.TrimEnd('/'));
+        return existingRedirects.TotalItems > 0;
+    }
+    
+    public HttpResponseMessage ImportExcel(Stream fileStream, bool importFile, string domain)
+    {
+        SetDomain(domain);
+        fileStream.Position = 0;
+        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+
+        using var reader = ExcelReaderFactory.CreateReader(fileStream);
+        var result = reader.AsDataSet();
+        var dataTable = result.Tables[0]; 
+            
+        var parsedData = new Dictionary<string, string>();
+            
+        for (var i = 0; i < dataTable.Rows.Count; i++)
+        {
+            var row = dataTable.Rows[i];
+            if (row.ItemArray.Length != 2)
+            {
+                return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"only 2 columns allowed on row {i + 1}" };
+            }
+                
+            var fromUrl = row[0].ToString();
+            var toUrl = row[1].ToString();
+                
+            if (!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl))
+            {
+                if (UrlExists(fromUrl))
+                {
+                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Redirect already exists for 'from' URL: {fromUrl} validation aborted." };
+                }
+                parsedData.Add(fromUrl, toUrl);
+            }
+            else
+            {
+                return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"row {i + 1}" };
+            }
+        }
+
+        if (importFile)
+        {
+            foreach (var entry in parsedData)
+            {
+                this.SaveRedirect(entry);
+            }
+        }
+
+        return new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
+    }
+
+    private void SetDomain(string domain)
+    {
+        int.TryParse(domain, out var domainId);
+        using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
+
+        var foundDomain = ctx.UmbracoContext.Domains?.GetAll(false).FirstOrDefault(it => it.Id == domainId);
+        if (foundDomain is not null)
+        {
+            _selectedDomain = foundDomain;;
+        }
+    }
+    
+    private void SaveRedirect(KeyValuePair<string, string> entry)
+    {
+        var redirect = new Redirect 
+        { 
+            Domain = _selectedDomain,
+            CustomDomain = null,
+            Id = 0,
+            IsEnabled = true,
+            IsRegex = false,
+            NewNodeCulture = null,
+            NewNode = null,
+            NewUrl = entry.Value,
+            OldUrl = entry.Key,
+            RedirectCode = 301
+        };
+
+        _redirectsService.Save(redirect);
+    }
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
@@ -1,13 +1,19 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
+using System.Text;
+using ExcelDataReader;
+using Microsoft.AspNetCore.Http;
 using Microsoft.VisualBasic.FileIO;
+using SeoToolkit.Umbraco.Redirects.Core.Constants;
+using SeoToolkit.Umbraco.Redirects.Core.Enumerators;
 using SeoToolkit.Umbraco.Redirects.Core.Interfaces;
 using SeoToolkit.Umbraco.Redirects.Core.Models.Business;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Routing;
 using Umbraco.Cms.Core.Web;
+using Umbraco.Extensions;
 
 namespace SeoToolkit.Umbraco.Redirects.Core.Helpers;
 
@@ -16,16 +22,83 @@ public class RedirectsImportHelper
     private Domain _selectedDomain;
     private readonly IRedirectsService _redirectsService;
     private readonly IUmbracoContextFactory _umbracoContextFactory;
+    private readonly IHttpContextAccessor _httpContextAccessor;
 
-    public RedirectsImportHelper(IRedirectsService redirectsService, IUmbracoContextFactory umbracoContextFactory)
+    public RedirectsImportHelper(IRedirectsService redirectsService, IUmbracoContextFactory umbracoContextFactory, IHttpContextAccessor httpContextAccessor)
     {
         _redirectsService = redirectsService;
         _umbracoContextFactory = umbracoContextFactory;
+        _httpContextAccessor = httpContextAccessor;
     }
 
-    public  HttpResponseMessage ImportCsv(Stream fileStream, bool importFile, string domain)
+    public Attempt<Dictionary<string,string>?, string> Validate(ImportRedirectsFileExtension fileExtension, MemoryStream memoryStream, string domain)
     {
         SetDomain(domain);
+        Attempt<Dictionary<string,string>, string> validationResult;
+        switch (fileExtension)
+        {
+            case ImportRedirectsFileExtension.Csv:
+                validationResult = ValidateCsv(memoryStream);
+                break;
+            case ImportRedirectsFileExtension.Excel:
+                validationResult = ValidateExcel(memoryStream);
+                break;
+            default:
+                return Attempt<Dictionary<string,string>?, string>.Fail("Invalid filetype, you may only use .csv or .xls", result: null);
+        }
+
+        if (validationResult.Success)
+        {
+            if (_httpContextAccessor.HttpContext is null)
+            {
+                return Attempt<Dictionary<string,string>?, string>.Fail("Could not access context", result: null);
+            }
+            // Storing the file contents in session for later import
+            _httpContextAccessor.HttpContext.Session.Set(ImportConstants.SessionAlias, memoryStream.ToArray());
+            _httpContextAccessor.HttpContext.Session.SetString(ImportConstants.SessionFileTypeAlias, fileExtension.ToString());
+            _httpContextAccessor.HttpContext.Session.SetString(ImportConstants.SessionDomainId, domain);
+            return Attempt<Dictionary<string,string>?, string>.Succeed(string.Empty, validationResult.Result);
+        }
+
+        return validationResult;
+    }
+
+    public Attempt<Dictionary<string,string>?, string> Import(ImportRedirectsFileExtension fileExtension, MemoryStream memoryStream, string domain)
+    {
+        SetDomain(domain);
+        var validation = Validate(fileExtension, memoryStream, domain);
+        if (validation is { Success: true, Result: not null } && validation.Result.Count != 0)
+        {
+            foreach (var entry in validation.Result)
+            {
+                SaveRedirect(entry);
+            }
+        }
+
+        return validation;
+    }
+
+    private bool UrlExists(string oldUrl)
+    {
+        var existingRedirects = _redirectsService.GetAll(1, 10, null, null, oldUrl.TrimEnd('/'));
+        if (existingRedirects.TotalItems > 0 && existingRedirects.Items is not null)
+        {
+            if (existingRedirects.Items.Count(x => x.Domain is null || x.Domain.Id == 0) > 0)
+            {
+                //url exists without any domain set
+                return true;
+            }
+            if (existingRedirects.Items.Count(x => x.Domain == _selectedDomain) > 0)
+            {
+                //url exists with specific domain set
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Attempt<Dictionary<string,string>?, string> ValidateCsv(Stream fileStream)
+    {
         //This currently assumes no header, and only 2 columns, from and to url
         fileStream.Position = 0;
         using (var reader = new StreamReader(fileStream))
@@ -33,113 +106,134 @@ public class RedirectsImportHelper
         {
             parser.TextFieldType = FieldType.Delimited;
             parser.SetDelimiters(",");
-            var parsedData = new Dictionary<string,string>(); 
-            
+            var parsedData = new Dictionary<string,string>();
+
             while (!parser.EndOfData)
             {
                 var fields = parser.ReadFields();
+
                 if (fields?.Length != 2)
                 {
-                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Validation failed: only 2 columns allowed on line {parser.LineNumber}" };
+                    return Attempt<Dictionary<string,string>?, string>.Fail($"Validation Fail: only 2 columns allowed on line {parser.LineNumber}", result: null);
                 }
-                
-                if(!string.IsNullOrWhiteSpace(fields[0]) && !string.IsNullOrWhiteSpace(fields[1])){
-                    
-                    if(UrlExists(fields[0]))
+                var fromUrl = CleanFromUrl(fields[0]);
+                var toUrl = Uri.IsWellFormedUriString(fields[1], UriKind.Absolute) ?
+                    fields[1] :
+                    fields[1].EnsureEndsWith("/").ToLower();
+
+                if(!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl)){
+
+                    if (!Uri.IsWellFormedUriString(fromUrl, UriKind.Relative))
                     {
-                        return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Redirect already exists for 'from' URL: {fields[0]} validation aborted." };
+                        return Attempt<Dictionary<string,string>?, string>.Fail($"line {parser.LineNumber}", result: null);
                     }
-                    parsedData.Add(fields[0], fields[1]);
-                    
+                    if(UrlExists(fromUrl))
+                    {
+                        return Attempt<Dictionary<string,string>?, string>.Fail($"Redirect already exists for 'from' URL: {fromUrl} validation aborted.", result: null);
+                    }
+                    parsedData.Add(fromUrl, toUrl);
+
                 }
                 else
                 {
-                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"line {parser.LineNumber}" };
+                    return Attempt<Dictionary<string,string>?, string>.Fail($"line {parser.LineNumber}", result: null);
                 }
             }
-
-            if (importFile)
-            {
-                foreach (var entry in parsedData)
-                {
-                    this.SaveRedirect(entry);
-                }
-            }
+            return Attempt<Dictionary<string,string>?, string>.Succeed(string.Empty, parsedData);
         }
 
-        return new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
+
     }
-    
-    private bool UrlExists(string oldUrl)
+    private Attempt<Dictionary<string,string>?, string> ValidateExcel(Stream fileStream)
     {
-        var existingRedirects = _redirectsService.GetAll(1, 10, null, null, oldUrl.TrimEnd('/'));
-        return existingRedirects.TotalItems > 0;
-    }
-    
-    public HttpResponseMessage ImportExcel(Stream fileStream, bool importFile, string domain)
-    {
-        SetDomain(domain);
         fileStream.Position = 0;
-        System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
         using var reader = ExcelReaderFactory.CreateReader(fileStream);
         var result = reader.AsDataSet();
-        var dataTable = result.Tables[0]; 
-            
+        var dataTable = result.Tables[0];
+
         var parsedData = new Dictionary<string, string>();
-            
+
         for (var i = 0; i < dataTable.Rows.Count; i++)
         {
             var row = dataTable.Rows[i];
             if (row.ItemArray.Length != 2)
             {
-                return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"only 2 columns allowed on row {i + 1}" };
+                return Attempt<Dictionary<string,string>?, string>.Fail($"only 2 columns allowed on row {i + 1}");
             }
-                
-            var fromUrl = row[0].ToString();
-            var toUrl = row[1].ToString();
-                
+
+            var fromUrl = CleanFromUrl(row[0].ToString());
+            var toUrl = Uri.IsWellFormedUriString(row[1].ToString(), UriKind.Absolute) ?
+                row[1].ToString() :
+                row[1].ToString()?.EnsureEndsWith("/").ToLower();
+
             if (!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl))
             {
+                if (!Uri.IsWellFormedUriString(fromUrl, UriKind.Relative))
+                {
+                    return Attempt<Dictionary<string,string>?, string>.Fail($"row {i + 1}", result: null);
+                }
+
                 if (UrlExists(fromUrl))
                 {
-                    return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"Redirect already exists for 'from' URL: {fromUrl} validation aborted." };
+                    return Attempt<Dictionary<string,string>?, string>.Fail($"Redirect already exists for 'from' URL: {fromUrl} validation aborted.");
                 }
                 parsedData.Add(fromUrl, toUrl);
             }
             else
             {
-                return new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, ReasonPhrase = $"row {i + 1}" };
+                return Attempt<Dictionary<string,string>?, string>.Fail($"row {i + 1}");
             }
         }
 
-        if (importFile)
-        {
-            foreach (var entry in parsedData)
-            {
-                this.SaveRedirect(entry);
-            }
-        }
-
-        return new HttpResponseMessage { StatusCode = HttpStatusCode.OK };
+        return Attempt<Dictionary<string,string>?, string>.Succeed(string.Empty, parsedData);
     }
 
     private void SetDomain(string domain)
     {
-        int.TryParse(domain, out var domainId);
-        using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
-
-        var foundDomain = ctx.UmbracoContext.Domains?.GetAll(false).FirstOrDefault(it => it.Id == domainId);
-        if (foundDomain is not null)
+        var parseSuccess = int.TryParse(domain, out var domainId);
+        if (!parseSuccess)
         {
-            _selectedDomain = foundDomain;;
+            domainId = 0;
         }
+
+        using var ctx = _umbracoContextFactory.EnsureUmbracoContext();
+        var foundDomain = ctx.UmbracoContext.Domains?.GetAll(false).FirstOrDefault(it => it.Id == domainId);
+        if (foundDomain is null)
+        {
+            return;
+        }
+
+        _selectedDomain = foundDomain;
     }
-    
+
+    private static string CleanFromUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+        var urlParts = url.ToLowerInvariant().Split('?');
+        if (urlParts.Length == 0)
+        {
+            return string.Empty;
+        }
+        var fromUrl = urlParts[0].TrimEnd('/');
+        if (urlParts.Length > 1)
+        {
+            fromUrl = $"{fromUrl}?{string.Join("?", urlParts.Skip(1))}";
+        }
+
+        fromUrl = fromUrl.EnsureStartsWith("/");
+
+        return fromUrl;
+    }
+
     private void SaveRedirect(KeyValuePair<string, string> entry)
     {
-        var redirect = new Redirect 
-        { 
+        var redirect = new Redirect
+        {
             Domain = _selectedDomain,
             CustomDomain = null,
             Id = 0,

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Models/Business/ImportStatus.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Models/Business/ImportStatus.cs
@@ -1,0 +1,13 @@
+﻿namespace SeoToolkit.Umbraco.Redirects.Core.Models.Business;
+
+public class ImportStatus
+{
+    public int StatusCode;
+    public string Error;
+
+    public ImportStatus(int statusCode, string error = "")
+    {
+        StatusCode = statusCode;
+        Error = error;
+    }
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/SeoToolkit.Umbraco.Redirects.Core.csproj
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/SeoToolkit.Umbraco.Redirects.Core.csproj
@@ -16,6 +16,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ExcelDataReader.DataSet" Version="3.7.0" />
+    <PackageReference Include="ExcelDataReader" Version="3.7.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\SeoToolkit.Umbraco.Common.Core\SeoToolkit.Umbraco.Common.Core.csproj" />
   </ItemGroup>
 

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/import.controller.js
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/import.controller.js
@@ -1,0 +1,136 @@
+﻿(function () {
+    "use strict";
+
+    function importController($http, $scope, formHelper, localizationService, redirectsApiResource, notificationsService) {
+
+        var vm = this;
+
+        vm.submit = submit;
+        vm.close = close;
+        vm.handleFiles = handleFiles;
+        vm.submit = submit;
+        vm.import = importFile;
+        vm.validated = false;
+        vm.validationSuccess = "";
+        vm.validationFailed = "";
+        vm.importSuccess = "";
+        vm.importFailed = "";
+        vm.fileTypePropertyLabel = "Select the file type";
+        vm.fileTypePropertyDescription = "Select the type of file you want to import the redirects from";
+        vm.filePropertyLabel = "Select a file to import";
+        vm.domainPropertyLabel = "Select the domain to import for";
+        vm.domainPropertyDescription = "if nothing is selected, redirects will be imported for all sites";
+
+        var labelKeys = [
+            "redirect_fileTypePropertyLabel", "redirect_fileTypePropertyDescription",
+            "redirect_filePropertyLabel",
+            "redirect_validationSuccess", "redirect_validationFailed",
+            "redirect_importSuccess", "redirect_importFailed",
+            "redirect_domainPropertyLabel","redirect_domainPropertyDescription",
+        ];
+        localizationService.localizeMany(labelKeys).then(function (data) {
+            vm.fileTypeSelection.label = data[0];
+            vm.fileTypeSelection.description = data[1];
+            vm.fileSelection.label = data[2];
+            vm.validationSuccess = data[3];
+            vm.validationFailed = data[4];
+            vm.importSuccess = data[5];
+            vm.importFailed = data[6];
+            vm.domainPropertyLabel = data[7];
+            vm.domainPropertyDescription = data[8];
+        });
+
+        vm.fileTypes = [
+            {
+                label:"CSV",
+                extension:".csv"
+            },
+            {
+                label:"Excel",
+                extension:".xls,.xlsx"
+            },
+        ];
+
+        vm.fileTypeSelection = {
+            alias: "fileType",
+            label: vm.fileTypePropertyLabel,
+            description: vm.fileTypePropertyDescription,
+            value: 0,
+            validation: {
+                mandatory: true
+            }
+        }
+
+        vm.domainSelection = {
+            alias: "domain",
+            label: vm.domainPropertyLabel,
+            description: vm.domainPropertyDescription,
+            value: "0",
+            validation: {
+                mandatory: true
+            }
+        }
+
+        vm.fileSelection = {
+            alias: "file",
+            label: vm.filePropertyLabel,
+            value: 0,
+            validation: {
+                mandatory: true
+            }
+        }
+
+        function handleFiles(files) {
+            if (files && files.length > 0) {
+                vm.fileSelection.value = files[0];
+            }
+        }
+
+        function submit() {
+            if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createRedirectForm })) {
+                redirectsApiResource.validateRedirects(vm.fileTypeSelection.value.label, vm.fileSelection.value, vm.domainSelection.value).then(function (response) {
+                    console.log(response);
+                    if (response.StatusCode == 200) {
+                        vm.notification = vm.validationSuccess;
+                        vm.validated = true;
+                    } else {
+                        vm.notification = `${vm.validationFailed} ${response.Error}`;
+                        vm.validated = false;
+                    }
+                });
+            }
+        }
+        function importFile() {
+            if (formHelper.submitForm({ scope: $scope, formCtrl: $scope.createRedirectForm })) {
+                redirectsApiResource.importRedirects().then(function (response) {
+                    if (response.StatusCode == 200) {
+                        notificationsService.success(`${vm.fileSelection.value.name} ${vm.importSuccess}`);
+                        vm.validated = true;
+                        $scope.model.close();
+                    } else {
+                        vm.notification = `${vm.importFailed} ${response.Error}`;
+                        vm.validated = false;
+                    }
+                });
+            }
+        }
+        function close() {
+            if ($scope.model.close) {
+                $scope.model.close();
+            }
+        }
+
+        init();
+
+        function init(){
+            $http.get("backoffice/SeoToolkit/Redirects/GetDomains").then(function (response) {
+                vm.domains = response.data.map(function (item) {
+                    return { id: item.Id, name: item.Name }
+                });
+                vm.domains.splice(0, 0, { id: 0, name: "All Sites" });
+            });
+        }
+    }
+
+    angular.module("umbraco").controller("SeoToolkit.Redirects.ImportController", importController);
+})();

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/import.html
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/import.html
@@ -1,0 +1,66 @@
+﻿<div ng-controller="SeoToolkit.Redirects.ImportController as vm">
+    <form name="createRedirectForm" novalidate val-form-manager ng-submit="vm.submit()" class="form-horizontal">
+        <umb-editor-view>
+            <umb-editor-header name="model.title"
+                               name-locked="true"
+                               hide-alias="true"
+                               hide-icon="true"
+                               hide-description="true">
+            </umb-editor-header>
+            <umb-editor-container class="block-form">
+                <umb-box>
+                    <umb-box-content>
+                        <umb-property property="vm.domainSelection">
+                            <div class="umb-property-editor">
+                                <select name="domainEditor" ng-model="vm.domainSelection.value">
+                                    <option ng-repeat="d in vm.domains" value="{{d.id}}">{{d.name}}</option>
+                                </select>
+                            </div>
+                        </umb-property>
+                        <umb-property property="vm.fileTypeSelection">
+                            <div class="umb-property-editor">
+                                <select name="fileTypeEditor"
+                                        ng-model="vm.fileTypeSelection.value"
+                                        ng-options="d.label for d in vm.fileTypes"></select>
+                            </div>
+                        </umb-property>
+                        <umb-property property="vm.fileSelection" ng-hide="vm.fileTypeSelection.value == '0'">
+                            <input type="file"
+                                   ngf-select
+                                   ng-model="vm.fileSelection.value"
+                                   ngf-change="vm.handleFiles($files, $event)"
+                                   ngf-multiple="false"
+                                   ngf-pattern="{{ vm.fileTypeSelection.value.extension }}"
+                                   accept="{{ vm.fileTypeSelection.value.extension }}">
+                            <umb-button  ng-hide="vm.fileSelection.value == ''" action="vm.submit()"
+                                         button-style="success"
+                                         label-key="general_submit"
+                                         state="saveButtonState">
+                            </umb-button>
+                        </umb-property>
+                        <div ng-hide="vm.notification.length == '0'" style="padding-top:10px" ng-class="{'red': vm.validated == false, 'text-success': vm.validated == true}">
+                            {{vm.notification}}
+                            <umb-button ng-hide="vm.validated == false"
+                                        action="vm.import()"
+                                        button-style="success"
+                                        label-key="import"
+                                        state="saveButtonState">
+                            </umb-button>
+                        </div>
+                    </umb-box-content>
+                </umb-box>
+            </umb-editor-container>
+            <umb-editor-footer>
+                <umb-editor-footer-content-right>
+                    <umb-button type="button"
+                                button-style="link"
+                                label-key="general_close"
+                                shortcut="esc"
+                                action="vm.close()">
+                    </umb-button>
+
+                </umb-editor-footer-content-right>
+            </umb-editor-footer>
+        </umb-editor-view>
+    </form>
+</div>

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/redirectsapi.resource.js
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/Dialogs/redirectsapi.resource.js
@@ -1,0 +1,25 @@
+﻿angular.module('umbraco.resources').factory('redirectsApiResource',
+    function (umbRequestHelper, Upload) {
+        // the factory object returned
+        var baseUrl = "backoffice/SeoToolkit/Redirects/";
+
+        return {
+            validateRedirects: function (fileExtension, file, domainId) {
+                return umbRequestHelper.resourcePromise(
+                    Upload.upload({
+                        url: baseUrl + 'ValidateRedirects?fileExtension=' + fileExtension + '&domain=' + domainId,
+                        file: file
+                    }),
+                    "Failed to import redirects"
+                );
+            },
+            importRedirects: function (fileExtension) {
+                return umbRequestHelper.resourcePromise(
+                    Upload.upload({
+                        url: baseUrl + 'ImportRedirects'
+                    }),
+                    "Failed to import redirects"
+                );
+            },
+        };
+    });

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/lang/en-us.xml
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/lang/en-us.xml
@@ -2,5 +2,15 @@
 <language alias="en">
 	<area alias="redirect">
 		<key alias="create">Create Redirect</key>
+		<key alias="importButton">Import redirects</key>
+		<key alias="fileTypePropertyLabel">Select the file type</key>
+		<key alias="fileTypePropertyDescription">Select the type of file you want to import the redirects from</key>
+		<key alias="filePropertyLabel">Select a file to import</key>
+		<key alias="validationSuccess">Validated successfully</key>
+		<key alias="validationFailed">Something went wrong: </key>
+		<key alias="importSuccess">Imported successfully</key>
+		<key alias="importFailed">Something went wrong: </key>
+		<key alias="domainPropertyLabel">Select the domain to import for</key>
+		<key alias="domainPropertyDescription">if nothing is selected, redirects will be active for all domains</key>
 	</area>
 </language>

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/lang/nl-nl.xml
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/lang/nl-nl.xml
@@ -2,5 +2,15 @@
 <language alias="nl">
 	<area alias="redirect">
 		<key alias="create">Redirect aanmaken</key>
+		<key alias="importButton">Redirects importeren</key>
+		<key alias="fileTypePropertyLabel">Selecteer het type bestand</key>
+		<key alias="fileTypePropertyDescription">Selecteer hier het type bestand dat geimporteerd moet worden</key>
+		<key alias="filePropertyLabel">Selecteer het bestand</key>
+		<key alias="validationSuccess">Gevalideerd</key>
+		<key alias="validationFailed">Er ging iets mis: </key>
+		<key alias="importSuccess">Succesvol geimporteerd</key>
+		<key alias="importFailed">Er ging iets mis: </key>
+		<key alias="domainPropertyLabel">Selecteer hier het domein</key>
+		<key alias="domainPropertyDescription">Als niets is geselecteerd worden de redirects actief voor alle domeinen</key>
 	</area>
 </language>

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/package.manifest
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/Redirects/package.manifest
@@ -2,7 +2,9 @@
   "javascript": [
     "/App_Plugins/SeoToolkit/backoffice/Redirects/list.controller.js",
     "/App_Plugins/SeoToolkit/Redirects/Dialogs/createRedirect.controller.js",
-    "/App_Plugins/SeoToolkit/Redirects/Dialogs/linkPicker.controller.js"
+    "/App_Plugins/SeoToolkit/Redirects/Dialogs/linkPicker.controller.js",
+    "/App_Plugins/SeoToolkit/Redirects/Dialogs/redirectsapi.resource.js",
+    "/App_Plugins/SeoToolkit/Redirects/Dialogs/import.controller.js"
   ],
   "css": [
     "/App_Plugins/SeoToolkit/Redirects/css/main.css"

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.controller.js
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.controller.js
@@ -1,7 +1,7 @@
 ﻿(function () {
     "use strict";
 
-    function redirectListController($timeout, $http, listViewHelper, notificationsService, editorService) {
+    function redirectListController($timeout, $http, listViewHelper, notificationsService, editorService, localizationService) {
         var vm = this;
 
         vm.items = [];
@@ -37,7 +37,15 @@
         vm.search = search;
 
         vm.create = openRedirectDialog;
+        vm.import = openImportDialog;
         vm.deleteSelection = deleteSelection;
+
+        vm.dialogLabel = "import redirects"
+
+        var labelKeys = ["redirect_importButton"];
+        localizationService.localizeMany(labelKeys).then(function (data) {
+            vm.dialogLabel = data[0];
+        });
 
         vm.pageNumber = 1;
         vm.pageSize = 20;
@@ -96,6 +104,22 @@
 
         function search() {
             goToPage(1);
+        }
+
+        function openImportDialog(model) {
+            var redirectDialogOptions = {
+                title: vm.dialogLabel,
+                view: "/App_Plugins/SeoToolkit/Redirects/Dialogs/import.html",
+                size: "small",
+                close: function () {
+                    editorService.close();
+                }
+            };
+            if (model) {
+                redirectDialogOptions.redirect = model;
+            }
+
+            editorService.open(redirectDialogOptions);
         }
 
         function openRedirectDialog(model) {

--- a/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.html
+++ b/src/SeoToolkit.Umbraco.Redirects/wwwroot/backoffice/Redirects/list.html
@@ -10,6 +10,11 @@
                                 size="xs"
                                 label-key="redirect_create"
                                 action="vm.create()">Add Redirect</umb-button>
+                    <umb-button type="button"
+                                button-style="outline"
+                                size="xs"
+                                label-key="redirect_importButton"
+                                action="vm.import()">Import redirects</umb-button>
                 </umb-editor-sub-header-content-left>
 
                 <umb-editor-sub-header-content-left ng-if="vm.selection.length > 0">
@@ -19,7 +24,7 @@
                                 label-key="buttons_clearSelection"
                                 action="vm.clearSelection()">Clear Selection</umb-button>
                 </umb-editor-sub-header-content-left>
-                
+
                 <umb-editor-sub-header-content-right ng-if="vm.selection.length == 0">
                     <umb-mini-search model="vm.searchFilter" on-search="vm.search()">
 
@@ -34,9 +39,9 @@
                                 action="vm.deleteSelection()">Delete</umb-button>
                 </umb-editor-sub-header-content-right>
             </umb-editor-sub-header>
-            
+
             <umb-load-indicator ng-if="vm.loading"></umb-load-indicator>
-            
+
             <div ng-if="!vm.loading">
                 <umb-table class="redirects-table"
                            items="vm.items"


### PR DESCRIPTION
Title says it all.

Added option to import redirects by a Csv / Excel file

Things I might add based on feedback
- Currently forces all added redirects to 301. Not sure if this should be an option / field in the import sheet
- Currently only supports 2 cells, a from and to url and only plain text (so no regex)
- Might add feature that also checks the imported url and gives a warning/notification based on if there is a page at all for that url.
- - Example: I have a 'toUrl' called '/some-news-page'. But that page does **not exists** in the CMS, could be nice to give a warning 
- - Example: I have a 'fromUrl' called '/some-news-page'. But that page **exists** in the CMS, could be nice to give a warning

Feedback / improvements are always welcome!