### PR TITLE
Added option to supress the "SEO settings have been saved" notification

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Controllers/SeoSettingsController.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Controllers/SeoSettingsController.cs
@@ -27,6 +27,7 @@ namespace SeoToolkit.Umbraco.Common.Core.Controllers
             return new JsonResult(new SeoSettingsViewModel
             {
                 IsEnabled = _seoSettingsService.IsEnabled(contentTypeId),
+                SupressContentAppSavingNotification = _seoSettingsService.SupressContentAppSavingNotification(), //TODO from settings
                 Displays = _displayCollection.Select(it => it.Get(contentTypeId)).WhereNotNull().ToArray()
             });
         }

--- a/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalAppSettingsModel.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalAppSettingsModel.cs
@@ -4,5 +4,6 @@
     {
         public bool AutomaticSitemapsInRobotsTxt { get; set; } = true;
         public bool EnableSeoSettingsByDefault { get; set; } = false; // TODO: Change this in a major version to true;
+        public bool SupressContentAppSavingNotification { get; set; } = false;
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalAppSettingsModel.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalAppSettingsModel.cs
@@ -4,6 +4,6 @@
     {
         public bool AutomaticSitemapsInRobotsTxt { get; set; } = true;
         public bool EnableSeoSettingsByDefault { get; set; } = false; // TODO: Change this in a major version to true;
-        public bool SupressContentAppSavingNotification { get; set; } = false;
+        public bool SupressContentAppSavingNotification { get; set; }
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalConfig.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Models/Config/GlobalConfig.cs
@@ -4,5 +4,6 @@
     {
         public bool AutomaticSitemapsInRobotsTxt { get; set; }
         public bool EnableSeoSettingsByDefault { get; set; }
+        public bool SupressContentAppSavingNotification { get; set; }
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Models/ViewModels/SeoSettingsViewModel.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Models/ViewModels/SeoSettingsViewModel.cs
@@ -5,6 +5,7 @@ namespace SeoToolkit.Umbraco.Common.Core.Models.ViewModels
     public class SeoSettingsViewModel
     {
         public bool IsEnabled { get; set; }
+        public bool SupressContentAppSavingNotification { get; set; }
         public SeoDisplayViewModel[] Displays { get; set; }
 
         public SeoSettingsViewModel()

--- a/src/SeoToolkit.Umbraco.Common.Core/Services/SeoSettingsService/ISeoSettingsService.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Services/SeoSettingsService/ISeoSettingsService.cs
@@ -3,6 +3,7 @@
     public interface ISeoSettingsService
     {
         bool IsEnabled(int contentTypeId);
+        bool SupressContentAppSavingNotification();
         void ToggleSeoSettings(int contentTypeId, bool value);
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Services/SeoSettingsService/SeoSettingsService.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Services/SeoSettingsService/SeoSettingsService.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using SeoToolkit.Umbraco.Common.Core.Caching;
 using SeoToolkit.Umbraco.Common.Core.Constants;
+using SeoToolkit.Umbraco.Common.Core.Models.Config;
 using SeoToolkit.Umbraco.Common.Core.Repositories.SeoSettingsRepository;
+using SeoToolkit.Umbraco.Common.Core.Services.SettingsService;
 using Umbraco.Cms.Core.Cache;
 using Umbraco.Extensions;
 
@@ -12,11 +14,13 @@ namespace SeoToolkit.Umbraco.Common.Core.Services.SeoSettingsService
         private readonly ISeoSettingsRepository _seoSettingsRepository;
         private readonly DistributedCache _distributedCache;
         private readonly IAppPolicyCache _cache;
+        private readonly ISettingsService<GlobalConfig> _settingsService;
 
-        public SeoSettingsService(ISeoSettingsRepository seoSettingsRepository, AppCaches appCaches, DistributedCache distributedCache)
+        public SeoSettingsService(ISeoSettingsRepository seoSettingsRepository, AppCaches appCaches, DistributedCache distributedCache, ISettingsService<GlobalConfig> settingsService)
         {
             _seoSettingsRepository = seoSettingsRepository;
             _distributedCache = distributedCache;
+            _settingsService = settingsService;
             _cache = appCaches.RuntimeCache;
         }
 
@@ -24,6 +28,11 @@ namespace SeoToolkit.Umbraco.Common.Core.Services.SeoSettingsService
         {
             return _cache.GetCacheItem($"{CacheConstants.SeoSettings}{contentTypeId}",
                 () => _seoSettingsRepository.IsEnabled(contentTypeId), TimeSpan.FromMinutes(10));
+        }
+
+        public bool SupressContentAppSavingNotification()
+        {
+            return _settingsService.GetSettings().SupressContentAppSavingNotification;
         }
 
         public void ToggleSeoSettings(int contentTypeId, bool value)

--- a/src/SeoToolkit.Umbraco.Common.Core/Services/SettingsService/GlobalConfigService.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Services/SettingsService/GlobalConfigService.cs
@@ -19,7 +19,8 @@ namespace SeoToolkit.Umbraco.Common.Core.Services.SettingsService
             return new GlobalConfig
             {
                 AutomaticSitemapsInRobotsTxt = settings.AutomaticSitemapsInRobotsTxt,
-                EnableSeoSettingsByDefault = settings.EnableSeoSettingsByDefault
+                EnableSeoSettingsByDefault = settings.EnableSeoSettingsByDefault,
+                SupressContentAppSavingNotification = settings.SupressContentAppSavingNotification,
             };
         }
     }

--- a/src/SeoToolkit.Umbraco.Common/wwwroot/ContentApps/DocumentType/seoSettings.controller.js
+++ b/src/SeoToolkit.Umbraco.Common/wwwroot/ContentApps/DocumentType/seoSettings.controller.js
@@ -32,7 +32,6 @@
         function init() {
             $http.get("backoffice/SeoToolkit/SeoSettings/Get?contentTypeId=" + $scope.model.id).then(
                 function (response) {
-                    console.log(response);
                     if (response.status === 200) {
                         vm.model.enableSeoSettings = response.data.isEnabled;
                         vm.model.supressContentAppSavingNotification = response.data.supressContentAppSavingNotification;
@@ -55,8 +54,6 @@
                     } else {
                         if(!vm.model.supressContentAppSavingNotification){
                             notificationsService.success("SEO settings saved!");
-                        } else {
-                            console.log("supressed!");
                         }
                     }
                 });

--- a/src/SeoToolkit.Umbraco.Common/wwwroot/ContentApps/DocumentType/seoSettings.controller.js
+++ b/src/SeoToolkit.Umbraco.Common/wwwroot/ContentApps/DocumentType/seoSettings.controller.js
@@ -13,7 +13,7 @@
         vm.model = {
             enableSeoSettings: false
         }
-
+        vm.model.supressSavingNotification = false;
         vm.setSeoSettings = function (value) {
             vm.model.enableSeoSettings = value;
         }
@@ -32,8 +32,10 @@
         function init() {
             $http.get("backoffice/SeoToolkit/SeoSettings/Get?contentTypeId=" + $scope.model.id).then(
                 function (response) {
+                    console.log(response);
                     if (response.status === 200) {
                         vm.model.enableSeoSettings = response.data.isEnabled;
+                        vm.model.supressContentAppSavingNotification = response.data.supressContentAppSavingNotification;
                         vm.displays = response.data.displays;
                         vm.displays[0].active = true;
 
@@ -51,7 +53,11 @@
                     if (response.status !== 200) {
                         notificationsService.error("Something went wrong while saving SEO settings");
                     } else {
-                        notificationsService.success("SEO settings saved!");
+                        if(!vm.model.supressContentAppSavingNotification){
+                            notificationsService.success("SEO settings saved!");
+                        } else {
+                            console.log("supressed!");
+                        }
                     }
                 });
         }

--- a/src/SeoToolkit.Umbraco.Site/appsettings.json
+++ b/src/SeoToolkit.Umbraco.Site/appsettings.json
@@ -28,7 +28,8 @@
   },
   "SeoToolkit": {
     "Global": {
-      "AutomaticSitemapsInRobotsTxt": false
+      "AutomaticSitemapsInRobotsTxt": false,
+      "SupressContentAppSavingNotification": false
     },
     "SiteAudit": {
       "MinimumDelayBetweenRequest": 2,


### PR DESCRIPTION
As title.

During development I (we) find it very annoying that each time you edit an document type, you get the seo settings have been saved, when there have been no changes to it.

Ideally the models should be compared (on load and on save) and shown the proper notification for it. But that's a lot more work :-) 

I've added an configurable option so you can suppress the "SEO settings have been saved" notification, so you aren't muscle memoried / tricked (clicking the next doc type on appearal of green notification) when the documentType settings hasn't been saved yet but the seosettings have been :) I think this is ideal for a user's development environment.

If I interpreted correctly, the seosettings-save is always done before the doctype-save, so no issues should appear.