### PR TITLE
#316: Moved buttons to footer for Redirects modals

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/popups/ItemGroupPicker.element.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/popups/ItemGroupPicker.element.ts
@@ -94,26 +94,26 @@ export default class ItemGroupPicker extends UmbModalBaseElement<
           `
         )}
 
-        <div class="actions">
+        <umb-footer-layout slot="footer">
           <uui-button
-            slot="actions"
             id="close"
             label="Close"
             look="primary"
             color="danger"
+            slot="actions"
             @click="${this.#handleClose}"
             >Close</uui-button
           >
           <uui-button
-            slot="actions"
             id="save"
             label="Submit"
             look="primary"
             color="positive"
+            slot="actions"
             @click="${this.#handleSubmit}"
             >Submit</uui-button
           >
-        </div>
+        </umb-footer-layout>
       </umb-body-layout>
     `;
   }

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
@@ -127,10 +127,6 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
     this.model?.update(newValue);
   }
 
-  #handleClose() {
-    this.modalContext?.reject();
-  }
-
   #handleSubmit() {
     const modelValue = this.model!.getValue();
 
@@ -239,26 +235,20 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
           </umb-property-dataset>
         </uui-box>
 
-        <div class="actions">
-          <uui-button
-            slot="actions"
-            id="close"
-            label="Close"
-            look="primary"
-            color="danger"
-            @click="${this.#handleClose}"
-            >Close</uui-button
-          >
-          <uui-button
-            slot="actions"
-            id="save"
-            label="Submit"
-            look="primary"
-            color="positive"
-            @click="${this.#handleSubmit}"
-            >Submit</uui-button
-          >
-        </div>
+        <umb-workspace-footer slot="footer" data-mark="workspace:footer">
+			<slot name="footer-info"></slot>
+			<slot name="actions" slot="actions" data-mark="workspace:footer-actions">
+                <uui-button
+                    slot="actions"
+                    id="save"
+                    label="Submit"
+                    look="primary"
+                    color="positive"
+                    @click="${this.#handleSubmit}"
+                    >Submit</uui-button
+                  >
+            </slot>
+		</umb-workspace-footer>
       </umb-body-layout>
     `;
   }

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
@@ -199,10 +199,6 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
     });
   }
 
-  #handleClose() {
-    this.modalContext?.reject();
-  }
-
   #handleSubmit() {
     this.value = {
       redirect: {
@@ -318,26 +314,20 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
           </umb-property-dataset>
         </uui-box>
 
-        <div class="actions">
-          <uui-button
-            slot="actions"
-            id="close"
-            label="Close"
-            look="primary"
-            color="danger"
-            @click="${this.#handleClose}"
-            >Close</uui-button
-          >
-          <uui-button
-            slot="actions"
-            id="save"
-            label="Submit"
-            look="primary"
-            color="positive"
-            @click="${this.#handleSubmit}"
-            >Submit</uui-button
-          >
-        </div>
+        <umb-workspace-footer slot="footer" data-mark="workspace:footer">
+			<slot name="footer-info"></slot>
+			<slot name="actions" slot="actions" data-mark="workspace:footer-actions">
+                <uui-button
+                    slot="actions"
+                    id="save"
+                    label="Submit"
+                    look="primary"
+                    color="positive"
+                    @click="${this.#handleSubmit}"
+                    >Submit</uui-button
+                  >
+            </slot>
+		</umb-workspace-footer>
       </umb-body-layout>
     `;
   }

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
@@ -117,10 +117,6 @@ export default class ImportRedirectsModal extends UmbModalBaseElement {
     this.State?.update(newValue);
   }
 
-  #handleClose() {
-    this.modalContext?.reject();
-  }
-
   async #handleValidate() {
     const state = this.State.getValue();
     const result = await this.#redirectRepository.verifyImport(
@@ -217,42 +213,36 @@ export default class ImportRedirectsModal extends UmbModalBaseElement {
             `
           )}
         </uui-box>
-        <div class="actions">
-          <uui-button
-            slot="actions"
-            id="close"
-            label="Close"
-            look="primary"
-            color="danger"
-            @click="${this.#handleClose}"
-            >Close</uui-button
-          >
-          ${when(
-            this.State.getValue().isValid,
-            () => html`
-              <uui-button
-                slot="actions"
-                id="save"
-                label="Submit"
-                look="primary"
-                color="positive"
-                @click="${this.#handleSubmit}"
-                >Submit</uui-button
-              >
-            `,
-            () => html`
-              <uui-button
-                slot="actions"
-                id="save"
-                label="Validate"
-                look="primary"
-                color="positive"
-                @click="${this.#handleValidate}"
-                >Validate</uui-button
-              >
-            `
-          )}
-        </div>
+        <umb-workspace-footer slot="footer" data-mark="workspace:footer">
+			<slot name="footer-info"></slot>
+			<slot name="actions" slot="actions" data-mark="workspace:footer-actions">
+                ${when(
+                    this.State.getValue().isValid,
+                    () => html`
+                      <uui-button
+                        slot="actions"
+                        id="save"
+                        label="Submit"
+                        look="primary"
+                        color="positive"
+                        @click="${this.#handleSubmit}"
+                        >Submit</uui-button
+                      >
+                    `,
+                            () => html`
+                      <uui-button
+                        slot="actions"
+                        id="save"
+                        label="Validate"
+                        look="primary"
+                        color="positive"
+                        @click="${this.#handleValidate}"
+                        >Validate</uui-button
+                      >
+                    `
+                )}
+            </slot>
+		</umb-workspace-footer>
       </umb-body-layout>
     `;
   }


### PR DESCRIPTION
Potential fix for #316 
Added a footer to the Redirects modals, and moved the submit buttons to this footer.
Also removed the cancel button since this is available in the footer automatically. Also removed the handleClose method since this is handled by the default cancel button automatically.