### PR TITLE
Parse dropdown values correctly

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditEditors/SeoDropdownEditEditor.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Common/SeoFieldEditEditors/SeoDropdownEditEditor.cs
@@ -14,7 +14,7 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Common.SeoFieldEditEditors
 
         public SeoDropdownEditEditor(string[] items)
         {
-            ValueConverter = new TextValueConverter();
+            ValueConverter = new SingleDropdownValueConverter();
             Config = new Dictionary<string, object>
             {
                 {"items",  items}


### PR DESCRIPTION
Fixes https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/313
Value was stored as a string, while it should have been converted from an array to a single item.