### PR TITLE
Add disabled state for NotFound component

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Constants/DisabledModuleConstant.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Constants/DisabledModuleConstant.cs
@@ -5,6 +5,7 @@
         public const string Middleware = "Middleware";
         public const string DocumentTypeContextApp = "DocumentTypeContextApp";
         public const string SectionTree = "SectionTree";
+        public const string LastChanceContentFinder = "LastChanceContentFinder";
         public const string All = "All";
     }
 }

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Components/DisableModuleComponent.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Components/DisableModuleComponent.cs
@@ -1,0 +1,25 @@
+﻿using Umbraco.Cms.Core.Composing;
+using SeoToolkit.Umbraco.Common.Core.Collections;
+using SeoToolkit.Umbraco.Common.Core.Enums;
+
+namespace SeoToolkit.Umbraco.NotFound.Core.Components
+{
+    internal class DisableModuleComponent : IComponent
+    {
+        private readonly ModuleCollection _collection;
+
+        public DisableModuleComponent(ModuleCollection collection)
+        {
+            _collection = collection;
+        }
+
+        public void Initialize()
+        {
+            _collection.SetStatus(NotFoundConstants.NotFoundModuleAlias, SeoToolkitModuleStatus.Disabled);
+        }
+
+        public void Terminate()
+        {
+        }
+    }
+}

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Composers/NotFoundComposer.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Composers/NotFoundComposer.cs
@@ -1,5 +1,10 @@
-﻿using SeoToolkit.Umbraco.NotFound.Core.Components;
+﻿using Microsoft.Extensions.Configuration;
+using SeoToolkit.Umbraco.Common.Core.Constants;
+using SeoToolkit.Umbraco.NotFound.Core.Components;
+using SeoToolkit.Umbraco.NotFound.Core.Config;
 using SeoToolkit.Umbraco.NotFound.Core.ContentFinders;
+using System;
+using System.Linq;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Extensions;
@@ -10,7 +15,21 @@ public class NotFoundComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
+        var section = builder.Config.GetSection("SeoToolkit:NotFound");
+        var settings = section?.Get<NotFoundAppSettingsModel>();
+        var disabledModules = settings?.DisabledModules ?? Array.Empty<string>();
+
+        if (disabledModules.Contains(DisabledModuleConstant.All))
+        {
+            builder.Components().Append<DisableModuleComponent>();
+            return;
+        }
+
+        if (!disabledModules.Contains(DisabledModuleConstant.LastChanceContentFinder))
+        {
+            builder.SetContentLastChanceFinder<PageNotFoundFinder>();
+        }
+
         builder.Components().Append<EnableModuleComponent>();
-        builder.SetContentLastChanceFinder<PageNotFoundFinder>();
     }
 }

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundAppSettingsModel.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundAppSettingsModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SeoToolkit.Umbraco.NotFound.Core.Config
+{
+    public class NotFoundAppSettingsModel
+    {
+        public string[] DisabledModules { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundConfigModel.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundConfigModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SeoToolkit.Umbraco.NotFound.Core.Config
+{
+    public class NotFoundConfigModel
+    {
+        public string[] DisabledModules { get; set; } = Array.Empty<string>();
+    }
+}

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundConfigurationService.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Config/NotFoundConfigurationService.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.Options;
+using SeoToolkit.Umbraco.Common.Core.Services.SettingsService;
+
+namespace SeoToolkit.Umbraco.NotFound.Core.Config
+{
+    public class NotFoundConfigurationService : DefaultAppSettingsService<NotFoundConfigModel>
+    {
+        private readonly IOptionsMonitor<NotFoundAppSettingsModel> _config;
+
+        public NotFoundConfigurationService(IOptionsMonitor<NotFoundAppSettingsModel> config)
+        {
+            _config = config;
+        }
+
+        public override NotFoundConfigModel GetSettings()
+        {
+            var settings = _config.CurrentValue;
+            return new NotFoundConfigModel
+            {
+                DisabledModules = settings.DisabledModules
+            };
+        }
+    }
+}


### PR DESCRIPTION
Added ability to disable the NotFound LastChanceContentFinder and the whole component in case this conflicts with any persons own implementations.

![image](https://github.com/user-attachments/assets/8a87e8dd-e278-4868-95c7-33f968db49d5)
