### PR TITLE
Updated redirect import validation logic to support HTTP status codes

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsController.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Controllers/RedirectsController.cs
@@ -1,23 +1,25 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using SeoToolkit.Umbraco.Common.Core.Controllers;
 using SeoToolkit.Umbraco.Redirects.Core.Constants;
 using SeoToolkit.Umbraco.Redirects.Core.Enumerators;
 using SeoToolkit.Umbraco.Redirects.Core.Helpers;
-using Umbraco.Cms.Core.Services;
-using Umbraco.Cms.Core.Web;
 using SeoToolkit.Umbraco.Redirects.Core.Interfaces;
 using SeoToolkit.Umbraco.Redirects.Core.Models.Business;
 using SeoToolkit.Umbraco.Redirects.Core.Models.PostModels;
 using SeoToolkit.Umbraco.Redirects.Core.Models.ViewModels;
-using Umbraco.Cms.Core.Security;
-using Umbraco.Extensions;
-using SeoToolkit.Umbraco.Common.Core.Controllers;
-using Umbraco.Cms.Web.Common.Routing;
-using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using System;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Umbraco.Cms.Api.Common.Builders;
+using Umbraco.Cms.Api.Common.ViewModels.Pagination;
+using Umbraco.Cms.Core.Security;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Services.OperationStatus;
+using Umbraco.Cms.Core.Web;
+using Umbraco.Cms.Web.Common.Routing;
+using Umbraco.Extensions;
 
 namespace SeoToolkit.Umbraco.Redirects.Core.Controllers
 {
@@ -181,7 +183,8 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Controllers
                 return Ok();
             }
 
-            return UnprocessableEntity(!string.IsNullOrWhiteSpace(result.Status) ? result.Status : "Something went wrong during the validation");
+            var problemDetailsBuilder = new ProblemDetailsBuilder();
+            return UnprocessableEntity(problemDetailsBuilder.WithOperationStatus(ContentEditingOperationStatus.Unknown).WithTitle(!string.IsNullOrWhiteSpace(result.Status) ? result.Status : "Something went wrong during the validation").Build());
         }
 
         [HttpPost("import")]

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Helpers/RedirectsImportHelper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using ExcelDataReader;
 using Microsoft.VisualBasic.FileIO;
@@ -27,39 +28,38 @@ public class RedirectsImportHelper
         _umbracoContextFactory = umbracoContextFactory;
     }
 
-    public Attempt<Dictionary<string,string>?, string> Validate(ImportRedirectsFileExtension fileExtension, MemoryStream memoryStream, int domain)
+    public Attempt<List<Redirect>, string> Validate(ImportRedirectsFileExtension fileExtension,
+        MemoryStream memoryStream, int domain)
     {
         SetDomain(domain);
-        Attempt<Dictionary<string,string>, string> validationResult;
+        Attempt<List<Redirect>, string> validationResult;
         switch (fileExtension)
         {
-            case ImportRedirectsFileExtension.Csv:
-                validationResult = ValidateCsv(memoryStream);
-                break;
-            case ImportRedirectsFileExtension.Excel:
-                validationResult = ValidateExcel(memoryStream);
-                break;
+            case ImportRedirectsFileExtension.Csv: validationResult = ValidateCsv(memoryStream); break;
+            case ImportRedirectsFileExtension.Excel: validationResult = ValidateExcel(memoryStream); break;
             default:
-                return Attempt<Dictionary<string,string>?, string>.Fail("Invalid filetype, you may only use .csv or .xls", result: null);
+                return Attempt<List<Redirect>, string>.Fail("Invalid filetype, you may only use .csv or .xls",
+                    result: null);
         }
 
         if (validationResult.Success)
         {
-            return Attempt<Dictionary<string,string>?, string>.Succeed(string.Empty, validationResult.Result);
+            return Attempt<List<Redirect>, string>.Succeed(string.Empty, validationResult.Result);
         }
 
         return validationResult;
     }
 
-    public Attempt<Dictionary<string,string>?, string> Import(ImportRedirectsFileExtension fileExtension, MemoryStream memoryStream, int domain)
+    public Attempt<List<Redirect>, string> Import(ImportRedirectsFileExtension fileExtension, MemoryStream memoryStream,
+        int domain)
     {
         SetDomain(domain);
         var validation = Validate(fileExtension, memoryStream, domain);
         if (validation is { Success: true, Result: not null } && validation.Result.Count != 0)
         {
-            foreach (var entry in validation.Result)
+            foreach (var redirect in validation.Result)
             {
-                SaveRedirect(entry);
+                _redirectsService.Save(redirect);
             }
         }
 
@@ -73,130 +73,138 @@ public class RedirectsImportHelper
         {
             if (existingRedirects.Items.All(x => x.OldUrl != oldUrl.TrimEnd('/')))
             {
-                //exact match not found
+                // exact match not found
                 return false;
             }
-            if (existingRedirects.Items.Count(x => x.Domain is null || x.Domain.Id == 0) > 0)
+
+            if (existingRedirects.Items.Any(x => x.Domain is null || x.Domain.Id == 0))
             {
-                //url exists without any domain set
+                // url exists without any domain set
                 return true;
             }
-            if (existingRedirects.Items.Count(x => x.Domain == _selectedDomain) > 0)
+
+            if (existingRedirects.Items.Any(x => x.Domain == _selectedDomain))
             {
-                //url exists with specific domain set
+                // url exists with specific domain set
                 return true;
             }
         }
+
         return false;
     }
 
-    private Attempt<Dictionary<string,string>?, string> ValidateCsv(Stream fileStream)
+    private Attempt<List<Redirect>, string> ValidateCsv(Stream fileStream)
     {
-        //This currently assumes no header, and only 2 columns, from and to url
+        // This currently assumes no header, and only 2 columns, from and to url
         fileStream.Position = 0;
-        using (var reader = new StreamReader(fileStream))
+        using var reader = new StreamReader(fileStream);
         using (var parser = new TextFieldParser(reader))
         {
             parser.TextFieldType = FieldType.Delimited;
             parser.SetDelimiters(",");
-            var parsedData = new Dictionary<string,string>();
-
+            var parsedData = new List<Redirect>();
             while (!parser.EndOfData)
             {
                 var fields = parser.ReadFields();
-
-                if (fields?.Length != 2)
+                if (fields?.Length is not (2 or 3))
                 {
-                    return Attempt<Dictionary<string,string>?, string>.Fail($"Validation Fail: only 2 columns allowed on line {parser.LineNumber}", result: null);
+                    return Attempt<List<Redirect>, string>.Fail(
+                        $"Validation Fail: only 2 columns allowed on line {parser.LineNumber}", result: null);
                 }
+
                 var fromUrl = CleanFromUrl(fields[0]);
-                var toUrl = Uri.IsWellFormedUriString(fields[1], UriKind.Absolute) ?
-                    fields[1] :
-                    fields[1].EnsureEndsWith("/").ToLower();
-
-                if(!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl)){
-
-                    if (!Uri.IsWellFormedUriString(fromUrl, UriKind.Relative))
+                var toUrl = Uri.IsWellFormedUriString(fields[1], UriKind.Absolute)
+                    ? fields[1]
+                    : fields[1].EnsureEndsWith("/").ToLower();
+                var redirectCode = GetRedirectCode(fields[2]);
+                if (!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl))
+                {
+                    var urlValidation = ValidateRedirectUrl(fromUrl, parsedData, parser.LineNumber);
+                    if (!urlValidation.Success)
                     {
-                        return Attempt<Dictionary<string,string>?, string>.Fail($"line {parser.LineNumber}", result: null);
+                        return urlValidation;
                     }
-                    if(UrlExists(fromUrl))
-                    {
-                        return Attempt<Dictionary<string,string>?, string>.Fail($"Redirect already exists for 'from' URL: {fromUrl} validation aborted.", result: null);
-                    }
-                    if (parsedData.ContainsKey(fromUrl.TrimEnd("/")))
-                    {
-                        return Attempt<Dictionary<string,string>?, string>.Fail($"Url appears more then one time in import file: {fromUrl}", result: null);
-                    }
-                    parsedData.Add(fromUrl, toUrl);
 
+                    var codeValidation = ValidateRedirectCode(redirectCode, fromUrl);
+                    if (!codeValidation.Success)
+                    {
+                        return codeValidation;
+                    }
+
+
+                    parsedData.Add(CreateRedirect(fromUrl, toUrl, redirectCode));
                 }
                 else
                 {
-                    return Attempt<Dictionary<string,string>?, string>.Fail($"line {parser.LineNumber}", result: null);
+                    return Attempt<List<Redirect>, string>.Fail($"line {parser.LineNumber}", result: null);
                 }
             }
-            return Attempt<Dictionary<string,string>?, string>.Succeed(string.Empty, parsedData);
+
+            return Attempt<List<Redirect>, string>.Succeed(string.Empty, parsedData);
         }
-
-
     }
-     private Attempt<Dictionary<string,string>?, string> ValidateExcel(Stream fileStream)
+
+    private Attempt<List<Redirect>, string> ValidateExcel(Stream fileStream)
     {
         fileStream.Position = 0;
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-
         try
         {
             using var reader = ExcelReaderFactory.CreateReader(fileStream);
             var result = reader.AsDataSet();
             var dataTable = result.Tables[0];
-
-            var parsedData = new Dictionary<string, string>();
-
+            var parsedData = new List<Redirect>();
             for (var i = 0; i < dataTable.Rows.Count; i++)
             {
                 var row = dataTable.Rows[i];
-                if (row.ItemArray.Length != 2)
+                if (row.ItemArray.Length is not (2 or 3))
                 {
-                    return Attempt<Dictionary<string, string>?, string>.Fail($"only 2 columns allowed on row {i + 1}");
+                    return Attempt<List<Redirect>, string>.Fail($"2 or 3 columns required on row {i + 1}");
                 }
 
                 var fromUrl = CleanFromUrl(row[0].ToString());
                 var toUrl = Uri.IsWellFormedUriString(row[1].ToString(), UriKind.Absolute)
                     ? row[1].ToString()
                     : row[1].ToString()?.EnsureEndsWith("/").ToLower();
-
+                var redirectCode = GetRedirectCode(row[2].ToString());
                 if (!string.IsNullOrWhiteSpace(fromUrl) && !string.IsNullOrWhiteSpace(toUrl))
                 {
-                    if (!Uri.IsWellFormedUriString(fromUrl, UriKind.Relative))
+                    var urlValidation = ValidateRedirectUrl(fromUrl, parsedData, i + 1);
+                    if (!urlValidation.Success)
                     {
-                        return Attempt<Dictionary<string, string>?, string>.Fail($"row {i + 1}", result: null);
+                        return urlValidation;
                     }
 
-                    if (UrlExists(fromUrl))
+                    var codeValidation = ValidateRedirectCode(redirectCode, fromUrl);
+                    if (!codeValidation.Success)
                     {
-                        return Attempt<Dictionary<string, string>?, string>.Fail(
-                            $"Redirect already exists for 'from' URL: {fromUrl} validation aborted.");
+                        return codeValidation;
                     }
-                    if (parsedData.ContainsKey(fromUrl.TrimEnd("/")))
-                    {
-                        return Attempt<Dictionary<string,string>?, string>.Fail($"Url appears more then one time in import file: {fromUrl}", result: null);
-                    }
-                    parsedData.Add(fromUrl, toUrl);
+
+                    parsedData.Add(CreateRedirect(fromUrl, toUrl, redirectCode));
                 }
                 else
                 {
-                    return Attempt<Dictionary<string, string>?, string>.Fail($"row {i + 1}");
+                    return Attempt<List<Redirect>, string>.Fail($"row {i + 1}");
                 }
             }
 
-            return Attempt<Dictionary<string, string>?, string>.Succeed(string.Empty, parsedData);
+            return Attempt<List<Redirect>, string>.Succeed(string.Empty, parsedData);
         }
         catch
         {
-            return Attempt<Dictionary<string, string>?, string>.Fail("Invalid file type");
+            return Attempt<List<Redirect>, string>.Fail("Invalid file type");
         }
+    }
+
+    private HttpStatusCode GetRedirectCode(string redirectCode)
+    {
+        return redirectCode switch
+        {
+            "301" => HttpStatusCode.MovedPermanently,
+            "302" => HttpStatusCode.Redirect,
+            _ => HttpStatusCode.MovedPermanently
+        };
     }
 
     private void SetDomain(int domain)
@@ -217,11 +225,13 @@ public class RedirectsImportHelper
         {
             return string.Empty;
         }
+
         var urlParts = url.ToLowerInvariant().Split('?');
         if (urlParts.Length == 0)
         {
             return string.Empty;
         }
+
         var fromUrl = urlParts[0].TrimEnd('/');
         if (urlParts.Length > 1)
         {
@@ -229,26 +239,48 @@ public class RedirectsImportHelper
         }
 
         fromUrl = fromUrl.EnsureStartsWith("/");
-
         return fromUrl;
     }
 
-    private void SaveRedirect(KeyValuePair<string, string> entry)
+    private Redirect CreateRedirect(string fromUrl, string toUrl, HttpStatusCode redirectCode)
     {
-        var redirect = new Redirect
+        return new Redirect
         {
-            Domain = _selectedDomain,
-            CustomDomain = null,
-            Id = 0,
-            IsEnabled = true,
-            IsRegex = false,
-            NewNodeCulture = null,
-            NewNode = null,
-            NewUrl = entry.Value,
-            OldUrl = entry.Key,
-            RedirectCode = 301
+            Domain = _selectedDomain, CustomDomain = null, Id = 0, IsEnabled = true, IsRegex = false,
+            NewNodeCulture = null, NewNode = null, NewUrl = toUrl, OldUrl = fromUrl, RedirectCode = (int)redirectCode
         };
-
-        _redirectsService.Save(redirect);
     }
+
+    private Attempt<List<Redirect>, string> ValidateRedirectUrl(string fromUrl, IEnumerable<Redirect> parsedData, long? rowNumber = null)
+    {
+        if (!Uri.IsWellFormedUriString(fromUrl, UriKind.Relative))
+        {
+            return Attempt<List<Redirect>, string>.Fail($"row {rowNumber ?? 0 + 1}", result: null);
+        }
+
+        if (UrlExists(fromUrl))
+        {
+            return Attempt<List<Redirect>, string>.Fail(
+                $"Redirect already exists for 'from' URL: {fromUrl} validation aborted.");
+        }
+
+        if (parsedData.Any(x => x.OldUrl == fromUrl.TrimEnd('/')))
+        {
+            return Attempt<List<Redirect>, string>.Fail(
+                $"Url appears more then one time in import file: {fromUrl}", result: null);
+        }
+
+        return Attempt<List<Redirect>, string>.Succeed(string.Empty, null);
+    }
+
+    private Attempt<List<Redirect>, string> ValidateRedirectCode(HttpStatusCode redirectCode, string fromUrl)
+    {
+        if (redirectCode is not (HttpStatusCode.Redirect or HttpStatusCode.MovedPermanently))
+        {
+            return Attempt<List<Redirect>, string>.Fail($"Only 301 and 302 are allowed: {fromUrl}", result: null);
+        }
+
+        return Attempt<List<Redirect>, string>.Succeed(string.Empty, null);
+    }
+
 }

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/dataLayer/RedirectSource.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/dataLayer/RedirectSource.ts
@@ -82,15 +82,18 @@ export class RedirectSource {
     domain?: number
   ) {
     return tryExecute(
-      this.#host,
-      SeoToolkitRedirectsService.postUmbracoSeoToolkitRedirectsValidate({
-        query: {
-          fileExtension: fileExtension! as ImportRedirectsFileExtension,
-          domain: domain!,
-          tempFileId: tempFileId!,
-        },
-      })
-    );
+        this.#host,
+        SeoToolkitRedirectsService.postUmbracoSeoToolkitRedirectsValidate({
+          query: {
+            fileExtension: fileExtension! as ImportRedirectsFileExtension,
+            domain: domain!,
+            tempFileId: tempFileId!,
+          },
+        }),
+        {
+          disableNotifications: true
+        }
+      );
   }
 
   async submitImport() {

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
@@ -131,8 +131,7 @@ export default class ImportRedirectsModal extends UmbModalBaseElement {
     if (result.error) {
       this.State.update({
         notification:
-          ((result.error)?.message as string) ??
-          "Something went wrong",
+          result.error.message ?? "Something went wrong",
       });
       return;
     }

--- a/src/package.json
+++ b/src/package.json
@@ -20,6 +20,11 @@
     "deploy": "npm run commonDeploy && npm run robotsTxtDeploy && npm run scriptManagerDeploy && npm run redirectDeploy && npm run sitemapDeploy && npm run siteAuditDeploy && npm run metaFieldsDeploy && npm run notFoundDeploy"
   },
   "dependencies": {
-    "concurrently": "^9.0.1"
+    "concurrently": "^9.0.1",
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5"
+  },
+  "devDependencies": {
+    "@umbraco-cms/backoffice": "^16.0.0"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -20,6 +20,7 @@
     "deploy": "npm run commonDeploy && npm run robotsTxtDeploy && npm run scriptManagerDeploy && npm run redirectDeploy && npm run sitemapDeploy && npm run siteAuditDeploy && npm run metaFieldsDeploy && npm run notFoundDeploy"
   },
   "dependencies": {
+    "@lit/context": "^1.1.5",
     "concurrently": "^9.0.1",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"

--- a/src/package.json
+++ b/src/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@lit/context": "^1.1.5",
     "concurrently": "^9.0.1",
+    "lit": "^3.3.0",
     "typescript": "^5.8.3",
     "vite": "^6.3.5"
   },


### PR DESCRIPTION
- Added packages to package.json so everything can build
- Added optional 301 and 302 statuscodes
- Now uses Redirect class instead of Dictionary<string,string>
- Moved double code to method.