### PR TITLE
Improve url handling for redirects (#390)

### DIFF
--- a/src/SeoToolkit.Tests/SeoToolkit.Tests/RedirectTests.cs
+++ b/src/SeoToolkit.Tests/SeoToolkit.Tests/RedirectTests.cs
@@ -73,6 +73,39 @@ namespace SeoToolkit.Tests
             redirectRepository.Verify(it => it.Save(It.Is<Redirect>(r => r.NewUrl.StartsWith("/") == shouldHaveSlash)), Times.Once);
         }
 
+        [TestCase("/hello-world", "/hello-world/")]
+        [TestCase("https://sw-unlimited-db.com", "https://sw-unlimited-db.com")]
+        [TestCase("/test?hello=1", "/test/?hello=1")]
+        public void TestEnsureTrailingSlash(string url, string expectedUrl)
+        {
+            // Arrange
+            var redirectRepository = new Mock<IRedirectsRepository>();
+            var bloomFilter = new Mock<IRedirectsBloomFilter>();
+
+            var umbracoContextFactory = GetContextFactoryWithDomain();
+
+            var requestHandlerSettings = new RequestHandlerSettings { AddTrailingSlash = true };
+            var optionsMonitor = new Mock<IOptionsMonitor<RequestHandlerSettings>>();
+            optionsMonitor.Setup(it => it.CurrentValue).Returns(requestHandlerSettings);
+
+            var redirectService = new RedirectsService(redirectRepository.Object, bloomFilter.Object, umbracoContextFactory, optionsMonitor.Object);
+
+            // Act
+            var redirect = new Redirect
+            {
+                Id = 1,
+                IsEnabled = true,
+                IsRegex = false,
+                OldUrl = "/test",
+                NewUrl = url,
+                RedirectCode = (int)HttpStatusCode.MovedPermanently
+            };
+            redirectService.Save(redirect);
+
+            // Assert
+            redirectRepository.Verify(it => it.Save(It.Is<Redirect>(r => r.NewUrl == expectedUrl)), Times.Once);
+        }
+
         private IUmbracoContextFactory GetContextFactoryWithDomain()
         {
             var umbracoContextFactory = new Mock<IUmbracoContextFactory>();

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Services/RedirectsService.cs
@@ -61,16 +61,22 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Services
 
             if (redirect.NewNode is null)
             {
-                newUrl = Uri.IsWellFormedUriString(newUrl, UriKind.Absolute) ?
-                    newUrl :
-                    newUrl.EnsureStartsWith("/").ToLower();
-                if (_requestHandlerSettings.AddTrailingSlash)
+                if (Uri.TryCreate(newUrl, UriKind.Relative, out Uri uri))
                 {
-                    newUrl = newUrl.EnsureEndsWith('/');
-                }
-                else
-                {
-                    newUrl = newUrl.TrimEnd('/');
+                    var path = uri.GetSafeAbsolutePath();
+                    var queryAndFragment = newUrl[path.Length..];
+                    path = path.EnsureStartsWith("/")
+                        .ToLower();
+                    if (_requestHandlerSettings.AddTrailingSlash)
+                    {
+                        path = path.EnsureEndsWith('/');
+                    }
+                    else
+                    {
+                        path = path.TrimEnd('/');
+                    }
+
+                    newUrl = $"{path}{queryAndFragment}";
                 }
             }
 


### PR DESCRIPTION
Added some extra checks to:
- don't do any manipulations on absolute url (trailling slash was messing with query and fragment here too, but also makes no sense that Umbraco setting impacts external links?)
- for relative: don't modify query and fragment