### PR TITLE
Fixes for various observable code

### DIFF
--- a/src/SeoToolkit.Umbraco.Common/assets/src/conditions/SeoEnabledCondition.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/conditions/SeoEnabledCondition.ts
@@ -25,7 +25,7 @@ export class SeoEnabledCondition
     super(host, args);
 
     this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (context) => {
-      context?.contentTypeUnique.subscribe((value) => {
+      this.observe(context?.contentTypeUnique, (value) => {
         if (!value) {
           return;
         }

--- a/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
@@ -30,7 +30,7 @@ export default class SeoToolkitDocumentContext
     super(host, ST_METAFIELDS_SETTINGSDOCUMENT_TOKEN_CONTEXT.toString());
 
     this.consumeContext(UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
-      instance?.unique.subscribe((value) => {
+      this.observe(instance?.unique, (value) => {
         this.#settingsRepository.getSettings(value!).then((resp) => {
           this.#model.update({
             contentTypeId: value?.toString(),

--- a/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/seoToolkitDocumentView.element.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/seoToolkitDocumentView.element.ts
@@ -50,7 +50,7 @@ export default class SeoToolkitDocumentViewElement extends UmbElementMixin(
     super();
 
     this.consumeContext(UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
-      instance?.isElement.subscribe((value) => {
+      this.observe(instance?.isElement, (value) => {
         this._showViews = !value;
       });
     });
@@ -58,9 +58,11 @@ export default class SeoToolkitDocumentViewElement extends UmbElementMixin(
     this.consumeContext(ST_METAFIELDS_SETTINGSDOCUMENT_TOKEN_CONTEXT, (instance) => {
       this.#context = instance;
 
-      instance?.model.subscribe((value) => {
+      this.observe(instance?.model, (value) => {
+        if (!value) return;
+
         this._seoEnabled = value.enabled;
-      })
+      });
     });
 
     new UmbExtensionsManifestInitializer(

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/propertyEditors/FieldsEditorPropertyEditor.element.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/propertyEditors/FieldsEditorPropertyEditor.element.ts
@@ -85,10 +85,10 @@ export default class FieldsEditorPropertyEditor
     this.#repository = new MetaFieldsSettingsRepository(this);
 
     this.consumeContext(UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
-      instance?.structure.contentTypes.subscribe((value) => {
+      this.observe(instance?.structure.contentTypes, (value) => {
         const contentTypeFields: FieldData[] = [];
 
-        value.forEach((field) => {
+        value?.forEach((field) => {
           field.properties.forEach((prop) => {
             if (this.dataTypesCache[prop.dataType.unique]) {
               if (

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
@@ -1,7 +1,5 @@
 import { UmbContextBase } from "@umbraco-cms/backoffice/class-api";
-import {
-  MetaFieldsSettingsViewModel,
-} from "../api";
+import { MetaFieldsSettingsViewModel } from "../api";
 import { UmbWorkspaceContext } from "@umbraco-cms/backoffice/workspace";
 import { UmbContextToken } from "@umbraco-cms/backoffice/context-api";
 import { MetaFieldsContentRepository } from "../dataAccess/MetaFieldsContentRepository";
@@ -26,8 +24,7 @@ export default class MetaFieldsContentContext
   #nodeId?: string;
   #cultures: string[] = [];
 
-  #variants: { [key: string]: MetaFieldsSettingsVariant } =
-    {};
+  #variants: { [key: string]: MetaFieldsSettingsVariant } = {};
 
   constructor(host: UmbControllerHost) {
     super(host, ST_METAFIELDS_CONTENT_TOKEN_CONTEXT.toString());
@@ -37,8 +34,8 @@ export default class MetaFieldsContentContext
     this.consumeContext(UMB_DOCUMENT_WORKSPACE_CONTEXT, (instance) => {
       this.#nodeId = instance?.getUnique()?.toString();
 
-      instance?.splitView.activeVariantsInfo.subscribe((variants) => {
-        variants.forEach((variant) => {
+      this.observe(instance?.splitView.activeVariantsInfo, (variants) => {
+        variants?.forEach((variant) => {
           const culture = variant.culture ?? "invariant";
           if (!this.#cultures.includes(culture)) {
             this.#cultures.push(culture);
@@ -46,22 +43,22 @@ export default class MetaFieldsContentContext
         });
         this.#loadDataFromRepository(this.#nodeId);
       });
-      instance?.unique.subscribe((unique) => {
+      this.observe(instance?.unique, (unique) => {
         this.#cultures.forEach((culture) => {
           delete this.#variants[culture];
-        })
+        });
         this.#loadDataFromRepository(unique?.toString());
       });
-      instance?.data.subscribe((item) => {
+      this.observe(instance?.data, (item) => {
         item?.variants.forEach((variant) => {
-          const culture = variant.culture ?? 'invariant';
+          const culture = variant.culture ?? "invariant";
           const currentDate = this.#getVariant(culture).lastUpdated;
           if (currentDate && currentDate !== variant.updateDate) {
             this.save(culture);
           }
 
           this.#getVariant(culture).lastUpdated = variant.updateDate;
-        })
+        });
       });
     });
   }
@@ -89,8 +86,8 @@ export default class MetaFieldsContentContext
     }
     this.#variants[variant] = {
       variant,
-      model: new UmbObjectState<MetaFieldsSettingsViewModel>({})
-    }
+      model: new UmbObjectState<MetaFieldsSettingsViewModel>({}),
+    };
     return this.#variants[variant];
   }
 

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentView.element.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentView.element.ts
@@ -41,11 +41,9 @@ export default class MetaFieldsContentView extends UmbElementMixin(LitElement) {
         }
         this.#context = instance;
         
-        instance
-          .getModel(this._culture!)
-          .subscribe((value) => {
-            this._model = value;
-          });
+        this.observe(instance.getModel(this._culture!), (value) => {
+          this._model = value;
+        });
       });
     });
   }

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsDocumentContext.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsDocumentContext.ts
@@ -34,7 +34,7 @@ export default class MetaFieldsDocumentContext
     this.#repository = new MetaFieldsSettingsRepository(host);
 
     this.consumeContext(UMB_DOCUMENT_TYPE_WORKSPACE_CONTEXT, (instance) => {
-      instance?.unique.subscribe((unique) => {
+      this.observe(instance?.unique, (unique) => {
         this.#nodeId = unique?.toString();
         this.fetchFromServer(unique!);
       });

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsDocumentView.element.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsDocumentView.element.ts
@@ -38,7 +38,7 @@ export default class MetaFieldsDocumentView extends UmbElementMixin(
       }
       this.#context = instance;
 
-      instance.model.subscribe((value) => {
+      this.observe(instance.model, (value) => {
         this._fields = value.fields ?? [];
 
         this._hasInheritance = !!value.inheritance && !!value.inheritance.id;

--- a/src/SeoToolkit.Umbraco.NotFound/assets/src/workspaces/NotFoundModuleWorkspace.element.ts
+++ b/src/SeoToolkit.Umbraco.NotFound/assets/src/workspaces/NotFoundModuleWorkspace.element.ts
@@ -28,7 +28,8 @@ export default class NotFoundModuleWorkspaceElement extends UmbElementMixin(
 
     this.consumeContext(ST_NOTFOUND_MODULE_TOKEN_CONTEXT, (instance) => {
       this.#context = instance;
-      instance?.content.subscribe((value) => {
+
+      this.observe(instance?.content, (value) => {
         this._content = {
           alias: "contentNode",
           value,

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/ImportRedirectsModal.element.ts
@@ -64,7 +64,7 @@ export default class ImportRedirectsModal extends UmbModalBaseElement {
     this._domains = (await this.#redirectRepository.getDomains()).data;
     this._domains.splice(0, 0, { id: 0, name: "All Sites" });
 
-    this.State.asObservable().subscribe((value) => {
+    this.observe(this.State.asObservable(), (value) => {
       const domain = value.domain
         ? this._domains.find((item) => item.id === value.domain)
         : undefined;

--- a/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/SiteAuditCreateWorkspace.element.ts
+++ b/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/SiteAuditCreateWorkspace.element.ts
@@ -39,7 +39,8 @@ export default class SiteAuditCreateWorkspace extends UmbLitElement {
         return;
       }
       this.#context = instance;
-      instance.model.subscribe((value) => {
+
+      this.observe(instance.model, (value) => {
         this._auditInformationProps = [
           {
             alias: "name",
@@ -74,7 +75,7 @@ export default class SiteAuditCreateWorkspace extends UmbLitElement {
         ];
       });
 
-      instance.config.subscribe((value) => {
+      this.observe(instance.config, (value) => {
         this._config = value;
       });
     });

--- a/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/detailViews/SiteAuditDetailMain.element.ts
+++ b/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/detailViews/SiteAuditDetailMain.element.ts
@@ -68,7 +68,7 @@ export default class SiteAuditDetailMain
       }
       this.#context = instance;
 
-      this.#context.model.subscribe((value) => {
+      this.observe(instance.model, (value) => {
         this._model = value;
 
         let errors = 0;

--- a/src/SeoToolkit.Umbraco.Sitemap/assets/src/workspaces/sitemapDocumentView.element.ts
+++ b/src/SeoToolkit.Umbraco.Sitemap/assets/src/workspaces/sitemapDocumentView.element.ts
@@ -46,7 +46,8 @@ export default class SitemapDocumentViewElement extends UmbElementMixin(LitEleme
                 return;
             }
             this.#context = instance;
-            instance.model.subscribe((item) => {
+
+            this.observe(instance.model, (item) => {
                 const changeFrequence = this.#changeFrequences.find((f) => f.value == item.changeFrequency)?.name;
                 const priority = this.#priorities.find((p) => p.value == item.priority)?.name;
                 this._content = [

--- a/src/SeoToolkit.Umbraco.Sitemap/assets/src/workspaces/sitemapDocumentViewContext.ts
+++ b/src/SeoToolkit.Umbraco.Sitemap/assets/src/workspaces/sitemapDocumentViewContext.ts
@@ -35,7 +35,7 @@ export default class SitemapDocumentViewContext
       if (!instance) {
         return;
       }
-      instance.unique.subscribe((unique) => {
+      this.observe(instance?.unique, (unique) => {
         this.#repository.getPageSettings(unique!).then((pageSettings) => {
           this.#model.update({
             contentTypeGuid: unique?.toString(),


### PR DESCRIPTION
Use this.observe instead of .subscribe as it will automatically clean up any subscriptions at the end of the component lifecycle