### PR TITLE
Ignore some type of links in the site audit

### DIFF
--- a/src/SeoToolkit.Umbraco.SiteAudit.Core/SiteCrawler/DefaultLinkParser.cs
+++ b/src/SeoToolkit.Umbraco.SiteAudit.Core/SiteCrawler/DefaultLinkParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using SeoToolkit.Umbraco.SiteAudit.Core.Interfaces;
 using SeoToolkit.Umbraco.SiteAudit.Core.Models.Business;
 
@@ -7,6 +8,8 @@ namespace SeoToolkit.Umbraco.SiteAudit.Core.SiteCrawler
 {
     public class DefaultLinkParser : ILinkParser
     {
+        private string[] _ignorePrefixesList = ["mailto:", "tel:", "file:", "javascript:"];
+
         public IEnumerable<Uri> GetLinks(CrawledPageModel page)
         {
             if (page is null)
@@ -20,6 +23,9 @@ namespace SeoToolkit.Umbraco.SiteAudit.Core.SiteCrawler
             foreach (var link in links)
             {
                 var hrefValue = link.Attributes["href"].Value;
+                if (_ignorePrefixesList.Any(it => hrefValue.StartsWith(it, StringComparison.InvariantCultureIgnoreCase)))
+                    continue;
+
                 yield return new Uri(baseUri, hrefValue);
             }
         }

--- a/src/SeoToolkit.Umbraco.SiteAudit.Core/SiteCrawler/DefaultLinkParser.cs
+++ b/src/SeoToolkit.Umbraco.SiteAudit.Core/SiteCrawler/DefaultLinkParser.cs
@@ -8,7 +8,7 @@ namespace SeoToolkit.Umbraco.SiteAudit.Core.SiteCrawler
 {
     public class DefaultLinkParser : ILinkParser
     {
-        private string[] _ignorePrefixesList = ["mailto:", "tel:", "file:", "javascript:"];
+        private static string[] _ignorePrefixesList = ["mailto:", "tel:", "file:", "javascript:"];
 
         public IEnumerable<Uri> GetLinks(CrawledPageModel page)
         {
@@ -22,11 +22,13 @@ namespace SeoToolkit.Umbraco.SiteAudit.Core.SiteCrawler
             var baseUri = page.Url;
             foreach (var link in links)
             {
-                var hrefValue = link.Attributes["href"].Value;
+                var hrefValue = link.Attributes["href"].Value.Trim();
                 if (_ignorePrefixesList.Any(it => hrefValue.StartsWith(it, StringComparison.InvariantCultureIgnoreCase)))
                     continue;
+                if (!Uri.TryCreate(baseUri, hrefValue, out var uriResult))
+                    continue;
 
-                yield return new Uri(baseUri, hrefValue);
+                yield return uriResult;
             }
         }
     }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Filter out non-HTTP links during site crawling

- Skip mailto, tel, file, and javascript links

- Improve link parsing accuracy for site audit


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Link Parser"] --> B["Check Link Prefix"]
  B --> C{"Is mailto/tel/file/javascript?"}
  C -->|Yes| D["Skip Link"]
  C -->|No| E["Process Link"]
  E --> F["Return URI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DefaultLinkParser.cs</strong><dd><code>Filter non-HTTP links in parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.SiteAudit.Core/SiteCrawler/DefaultLinkParser.cs

<ul><li>Added array of ignored link prefixes (mailto, tel, file, javascript)<br> <li> Added filtering logic to skip non-HTTP links<br> <li> Added System.Linq import for LINQ operations</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/412/files#diff-8d120f3a37818d3a994cbc0f00a64a1e330eaec1c97d3fc53ce006996f949111">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

