### PR TITLE
Implement correct domain check for not found

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Repositories/SeoKeyValueRepository/SeoKeyValueRepository.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Repositories/SeoKeyValueRepository/SeoKeyValueRepository.cs
@@ -38,10 +38,19 @@ namespace SeoToolkit.Umbraco.Common.Core.Repositories.SeoKeyValueRepository
         {
             using var scope = _scopeProvider.CreateScope(autoComplete: true);
 
-            var existingEntity = scope.Database.FirstOrDefault<SeoKeyValueEntity>(scope.SqlContext.Sql()
+            var sql = scope.SqlContext.Sql()
                 .SelectAll()
                 .From<SeoKeyValueEntity>()
-                .Where<SeoKeyValueEntity>(it => it.Key == key && it.DomainId == domainId));
+                .Where<SeoKeyValueEntity>(it => it.Key == key);
+            if (!domainId.HasValue)
+            {
+                sql = sql.Where<SeoKeyValueEntity>(it => it.DomainId == null);
+            }
+            else
+            {
+                sql = sql.Where<SeoKeyValueEntity>(it => it.DomainId == domainId);
+            }
+            var existingEntity = scope.Database.FirstOrDefault<SeoKeyValueEntity>(sql);
 
             existingEntity ??= new SeoKeyValueEntity
             {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix domain check logic for null domainId values

- Separate null and non-null domain filtering conditions

- Prevent incorrect entity matching in repository queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Query with domainId"] --> B{"domainId.HasValue?"}
  B -->|No| C["Filter: DomainId == null"]
  B -->|Yes| D["Filter: DomainId == domainId"]
  C --> E["Fetch existing entity"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeoKeyValueRepository.cs</strong><dd><code>Correct null domain filtering in Set method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Common.Core/Repositories/SeoKeyValueRepository/SeoKeyValueRepository.cs

<ul><li>Refactored domain filtering logic to handle null domainId correctly<br> <li> Split single Where clause into conditional branches for null and <br>non-null cases<br> <li> Prevents incorrect comparison when domainId is null (null == null <br>should match)</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/429/files#diff-87dd0ae4ebe42ad68754c753fb72ac84bf56c906b1e09121a04da8f01a096bb3">+11/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

