### PR TITLE
Fix lit imports

### DIFF
--- a/src/SeoToolkit.Umbraco.Common/assets/src/trees/SeoToolkitTreeItem.element.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/trees/SeoToolkitTreeItem.element.ts
@@ -1,7 +1,7 @@
 import { UmbTreeItemContext, UmbTreeItemElementBase } from "@umbraco-cms/backoffice/tree";
 import { SeoToolkitTreeItemModel } from "./types";
 import { css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property } from "@umbraco-cms/backoffice/external/lit";
 
 @customElement("seotoolkit-tree-item")
 export default class SeoToolkitTreeItemElement extends UmbTreeItemElementBase<SeoToolkitTreeItemModel> {

--- a/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDomainView.element.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDomainView.element.ts
@@ -2,11 +2,11 @@ import { css, html } from "lit";
 import SeoToolkitDomainContext, {
   ST_DOMAIN_DETAIL_TOKEN_CONTEXT,
 } from "./SeoToolkitDomainContext";
-import { customElement, state } from "lit/decorators.js";
 import { umbFocus, UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
 import { UUIInputElement } from "@umbraco-cms/backoffice/external/uui";
+import { customElement, state } from "@umbraco-cms/backoffice/external/lit";
 
-@customElement("seotoolkit.domain-detail")
+@customElement("seotoolkit-domain-detail")
 export default class SeoToolkitDomainViewElement extends UmbLitElement {
   #context?: SeoToolkitDomainContext;
 

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/popups/ItemGroupPicker.element.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/popups/ItemGroupPicker.element.ts
@@ -1,8 +1,6 @@
-import { classMap } from "@umbraco-cms/backoffice/external/lit";
+import { classMap, customElement, repeat, state } from "@umbraco-cms/backoffice/external/lit";
 import { UmbModalBaseElement } from "@umbraco-cms/backoffice/modal";
 import { css, html } from "lit";
-import { customElement, state } from "lit/decorators.js";
-import { repeat } from "lit/directives/repeat.js";
 
 export interface ItemGroupPickerConfig {
   items: ItemGroupPickerItem[];

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/workspaces/RedirectModuleWorkspace.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/workspaces/RedirectModuleWorkspace.element.ts
@@ -1,6 +1,6 @@
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { customElement } from "@umbraco-cms/backoffice/external/lit";
 import { html, LitElement } from "lit";
-import { customElement } from "lit/decorators.js";
 
 @customElement('seotoolkit-module-redirect')
 export class RedirectModuleWorkspace extends UmbElementMixin(LitElement) {

--- a/src/SeoToolkit.Umbraco.ScriptManager/assets/src/workspaces/ScriptManagerModuleWorkspace.element.ts
+++ b/src/SeoToolkit.Umbraco.ScriptManager/assets/src/workspaces/ScriptManagerModuleWorkspace.element.ts
@@ -1,6 +1,6 @@
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { customElement } from "@umbraco-cms/backoffice/external/lit";
 import { html, LitElement } from "lit";
-import { customElement } from "lit/decorators.js";
 
 @customElement('seotoolkit-module-scriptmanager')
 export class ScriptManagerModuleWorkspace extends UmbElementMixin(LitElement) {

--- a/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/SiteAuditModuleWorkspace.element.ts
+++ b/src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/SiteAuditModuleWorkspace.element.ts
@@ -1,6 +1,6 @@
 import { UmbElementMixin } from "@umbraco-cms/backoffice/element-api";
+import { customElement } from "@umbraco-cms/backoffice/external/lit";
 import { html, LitElement } from "lit";
-import { customElement } from "lit/decorators.js";
 
 @customElement('seotoolkit-module-site-audit')
 export class SiteAuditModuleWorkspace extends UmbElementMixin(LitElement) {


### PR DESCRIPTION
### **User description**
Backport lit imports fix


___

### **PR Type**
Bug fix


___

### **Description**
- Replace direct `lit/decorators.js` imports with Umbraco's external lit package

- Consolidate multiple lit imports into single `@umbraco-cms/backoffice/external/lit` import

- Fix custom element selector naming from dot notation to kebab-case

- Reorganize import statements for consistency across multiple components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lit/decorators.js<br/>lit/directives/repeat.js"] -->|Replace with| B["@umbraco-cms/backoffice/external/lit"]
  C["Scattered imports"] -->|Consolidate| D["Single import statement"]
  E["seotoolkit.domain-detail"] -->|Fix selector| F["seotoolkit-domain-detail"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeoToolkitTreeItem.element.ts</strong><dd><code>Update lit decorators import path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Common/assets/src/trees/SeoToolkitTreeItem.element.ts

<ul><li>Replace <code>lit/decorators.js</code> import with <br><code>@umbraco-cms/backoffice/external/lit</code></ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-4ec3680423b44cbe852444b7a3c0535ddcf768a9b070e41a2a2b92a6546e7c61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SeoToolkitDomainView.element.ts</strong><dd><code>Fix lit imports and custom element selector</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDomainView.element.ts

<ul><li>Replace <code>lit/decorators.js</code> import with <br><code>@umbraco-cms/backoffice/external/lit</code><br> <li> Reorganize imports to group related packages together<br> <li> Fix custom element selector from <code>seotoolkit.domain-detail</code> to <br><code>seotoolkit-domain-detail</code></ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-b87c1aa65fb94a65ffe77ddcc58d22a70881b7dfd96a57404b46809bba43b6a1">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ItemGroupPicker.element.ts</strong><dd><code>Consolidate lit imports into external package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.MetaFields/assets/src/popups/ItemGroupPicker.element.ts

<ul><li>Consolidate multiple lit imports into single <br><code>@umbraco-cms/backoffice/external/lit</code> import<br> <li> Remove separate <code>lit/decorators.js</code> and <code>lit/directives/repeat.js</code> imports<br> <li> Combine <code>classMap</code>, <code>customElement</code>, <code>repeat</code>, and <code>state</code> in one import <br>statement</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-0adfeee174449df078bb5134bc2f5873c85d02306de41366cd003e667c760b01">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RedirectModuleWorkspace.element.ts</strong><dd><code>Update lit decorators import path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Redirects/assets/src/workspaces/RedirectModuleWorkspace.element.ts

<ul><li>Replace <code>lit/decorators.js</code> import with <br><code>@umbraco-cms/backoffice/external/lit</code><br> <li> Reorder imports to place Umbraco packages before standard lit imports</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-c63d4b48af9885862ddfeb047a4a0b1b6f0dc60ab9c57b4ae1ab1cf75597998f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ScriptManagerModuleWorkspace.element.ts</strong><dd><code>Update lit decorators import path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.ScriptManager/assets/src/workspaces/ScriptManagerModuleWorkspace.element.ts

<ul><li>Replace <code>lit/decorators.js</code> import with <br><code>@umbraco-cms/backoffice/external/lit</code><br> <li> Reorder imports to place Umbraco packages before standard lit imports</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-502cfe1647a6163786d172cf5c87de55e30edfdf58dc7b9928e48626bf4607bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SiteAuditModuleWorkspace.element.ts</strong><dd><code>Update lit decorators import path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.SiteAudit/assets/src/workspaces/SiteAuditModuleWorkspace.element.ts

<ul><li>Replace <code>lit/decorators.js</code> import with <br><code>@umbraco-cms/backoffice/external/lit</code><br> <li> Reorder imports to place Umbraco packages before standard lit imports</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/446/files#diff-d87dc9d88a620fe3b9c8e8102014274af6ed54e60f68edfcaf2b159ccb270b0e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

