### PR TITLE
Fixed an issue where the event would trigger on the wrong type

### DIFF
--- a/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
@@ -76,7 +76,7 @@ export default class SeoToolkitDocumentContext
   }
 
   destroy(): void {
-    this.#actionEventContext?.removeEventListener("request-reload-structure-for-entity", this.#save);
+    this.#actionEventContext?.removeEventListener(UmbEntityUpdatedEvent.TYPE, this.#save);
   }
 }
 

--- a/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
+++ b/src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts
@@ -10,6 +10,7 @@ import { UmbWorkspaceContext } from "@umbraco-cms/backoffice/workspace";
 import { SeoSettingsPostModel } from "../api";
 import { UmbObjectState } from "@umbraco-cms/backoffice/observable-api";
 import { SeoToolkitSettingsRepository } from "../repositories/seoToolkitSettingsRepository";
+import { UmbEntityUpdatedEvent } from "@umbraco-cms/backoffice/entity-action";
 
 export default class SeoToolkitDocumentContext
   extends UmbContextBase
@@ -46,7 +47,10 @@ export default class SeoToolkitDocumentContext
       }
 
       this.#actionEventContext = instance;
-      instance.addEventListener("request-reload-structure-for-entity", this.#save);
+      this.#actionEventContext.addEventListener(
+        UmbEntityUpdatedEvent.TYPE,
+        this.#save
+      );
     });
   }
 
@@ -55,7 +59,10 @@ export default class SeoToolkitDocumentContext
   }
 
   public save() {
-    this.#settingsRepository.setSettings(this.#model.getValue());
+    const value = { ...this.#model.getValue() };
+    if (value.contentTypeId === "") return;
+
+    this.#settingsRepository.setSettings(value);
   }
 
   public setSeoSettings(value: boolean) {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed event listener to use correct UmbEntityUpdatedEvent type

- Added validation to prevent saving when contentTypeId is empty

- Imported UmbEntityUpdatedEvent from Umbraco backoffice library


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Listener Setup"] -->|"Changed from request-reload-structure-for-entity"| B["UmbEntityUpdatedEvent.TYPE"]
  C["Save Method"] -->|"Added validation"| D["Check contentTypeId not empty"]
  D -->|"If valid"| E["Save Settings"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeoToolkitDocumentContext.ts</strong><dd><code>Fix event type and add contentTypeId validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Common/assets/src/workspaces/SeoToolkitDocumentContext.ts

<ul><li>Imported <code>UmbEntityUpdatedEvent</code> from Umbraco backoffice library<br> <li> Changed event listener from <code>request-reload-structure-for-entity</code> to <br><code>UmbEntityUpdatedEvent.TYPE</code><br> <li> Added validation in <code>save()</code> method to prevent saving when <code>contentTypeId</code> <br>is empty<br> <li> Spread model value before passing to settings repository</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/448/files#diff-ea913cb144785986569313808ca4c29cc2c8cc3ae861ae234db9e143eaeae3f3">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

