### PR TITLE
Fix the issue with enable/disable not showing for module

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Models/SeoToolkitModule.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Models/SeoToolkitModule.cs
@@ -1,4 +1,5 @@
 ﻿using SeoToolkit.Umbraco.Common.Core.Enums;
+using System.Text.Json.Serialization;
 
 namespace SeoToolkit.Umbraco.Common.Core.Models
 {
@@ -8,6 +9,8 @@ namespace SeoToolkit.Umbraco.Common.Core.Models
         public string Alias { get; set; }
         public string Icon { get; set; }
         public string Link { get; set; }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
         public SeoToolkitModuleStatus Status { get; set; }
     }
 }


### PR DESCRIPTION
### **User description**
Fixes https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/455


___

### **PR Type**
Bug fix


___

### **Description**
- Add JSON serialization support for enum Status property

- Apply JsonConverter attribute to enable/disable module status serialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SeoToolkitModule Class"] -- "Add JsonConverter" --> B["Status Property Serialization"]
  B -- "Enables" --> C["Enable/Disable UI Display"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SeoToolkitModule.cs</strong><dd><code>Add JSON enum converter to Status property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Common.Core/Models/SeoToolkitModule.cs

<ul><li>Added <code>System.Text.Json.Serialization</code> namespace import<br> <li> Applied <code>[JsonConverter(typeof(JsonStringEnumConverter))]</code> attribute to <br><code>Status</code> property<br> <li> Enables proper JSON serialization of the <code>SeoToolkitModuleStatus</code> enum <br>value</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/456/files#diff-077849817ad3284d405f120e695dbd3e07ab01e988e7fe892ad8a1d822b00753">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

