### PR TITLE
Fix migration not running from the start

### DIFF
--- a/src/SeoToolkit.Umbraco.Common.Core/Migrations/SeoSettingsInitialMigration.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Migrations/SeoSettingsInitialMigration.cs
@@ -1,15 +1,16 @@
 ﻿using Umbraco.Cms.Infrastructure.Migrations;
 using SeoToolkit.Umbraco.Common.Core.Models.Database;
+using System.Threading.Tasks;
 
 namespace SeoToolkit.Umbraco.Common.Core.Migrations
 {
-    public class SeoSettingsInitialMigration : MigrationBase
+    public class SeoSettingsInitialMigration : AsyncMigrationBase
     {
         public SeoSettingsInitialMigration(IMigrationContext context)
             : base(context)
         { }
 
-        protected override void Migrate()
+        protected override Task MigrateAsync()
         {
             if (TableExists("uSeoToolkitSeoSettings"))
             {
@@ -19,6 +20,7 @@ namespace SeoToolkit.Umbraco.Common.Core.Migrations
             {
                 Create.Table<SeoSettingsEntity>().Do();
             }
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/SeoToolkit.Umbraco.Common.Core/Migrations/USeoToolkitMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.Common.Core/Migrations/USeoToolkitMigrationPlan.cs
@@ -10,6 +10,8 @@ namespace SeoToolkit.Umbraco.Common.Core.Migrations
             : base("SEO Toolkit", "SeoToolkit_Common_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<SeoSettingsInitialMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.Core/Startup/Migrations/SeoToolkitMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.Core/Startup/Migrations/SeoToolkitMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.Core.Startup.Migrations
         {
         }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<SitemapInRobotsTxtMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Migrations/MetaFieldsMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Migrations/MetaFieldsMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Migrations
             : base("SEO Toolkit: Meta Fields", "SeoToolkit_MetaFields_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<MetaFieldsInitialMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.NotFound.Core/Migrations/NotFoundMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.NotFound.Core/Migrations/NotFoundMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.NotFound.Core.Migrations
         {
         }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<NotFoundUmbraco13Migration>("state-1");

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/RedirectsMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Migrations/RedirectsMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Migrations
             : base("SEO Toolkit: Redirects", "SeoToolkit_Redirects_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<InitialRedirectsMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.RobotsTxt.Core/Migrations/RobotsTxtMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.RobotsTxt.Core/Migrations/RobotsTxtMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.RobotsTxt.Core.Migrations
             : base("SEO Toolkit: Robots.txt", "SeoToolkit_RobotsTxt_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<InitialRobotsTxtMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.ScriptManager.Core/Migrations/ScriptManagerMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.ScriptManager.Core/Migrations/ScriptManagerMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.ScriptManager.Core.Migrations
         : base("SEO Toolkit: Script Manager", "SeoToolkit_ScriptManager_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<ScriptManagerInitialMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.SiteAudit.Core/Migrations/SiteAuditMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.SiteAudit.Core/Migrations/SiteAuditMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.SiteAudit.Core.Migrations
             : base("SEO Toolkit: Site Audit", "SeoToolkit_SiteAudit_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<SiteAuditInitialMigration>("state-1");

--- a/src/SeoToolkit.Umbraco.Sitemap.Core/Migrations/SitemapMigrationPlan.cs
+++ b/src/SeoToolkit.Umbraco.Sitemap.Core/Migrations/SitemapMigrationPlan.cs
@@ -8,6 +8,8 @@ namespace SeoToolkit.Umbraco.Sitemap.Core.Migrations
         : base("SEO Toolkit: Sitemap", "SeoToolkit_Sitemap_Migration")
         { }
 
+        public override bool IgnoreCurrentState => false;
+
         protected override void DefinePlan()
         {
             To<SitemapInitialMigration>("state-1");


### PR DESCRIPTION
### **User description**
Temporary fix until Umbraco brings this change back: https://github.com/umbraco/Umbraco-CMS/issues/21730. Currently it causes all migrations to be ran while this doesn't really work with the big migration to Guids


___

### **PR Type**
Bug fix


___

### **Description**
- Convert initial migration to async pattern using `AsyncMigrationBase`

- Set `IgnoreCurrentState` to false in all migration plans

- Ensures migrations run from start instead of skipping based on state


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Migration Plans"] -- "Set IgnoreCurrentState to false" --> B["Skip State Validation"]
  C["SeoSettingsInitialMigration"] -- "Convert to AsyncMigrationBase" --> D["Async Migration Pattern"]
  B --> E["Migrations Run from Start"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>SeoSettingsInitialMigration.cs</strong><dd><code>Convert migration to async base class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-bee500fa9ceaea670229fcf1a7659d8d0275637922f22352b2913ee878386069">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>USeoToolkitMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-6af124f6bdeda398241a07985519722888e5ccd47421ef15734827839b2fca5f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SeoToolkitMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-3609b9c9553f37dcca197983534d4389254bc93fa3aaf859006ec32512487e03">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MetaFieldsMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-8b3fa2c45109b31d31a4a55d1f569ab479c0cc21b8f8f743beccaa01a339cca7">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NotFoundMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-e1c9472670218788ca300b83e229c902ad9fc213aec343cabfc30fa4caba1a35">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RedirectsMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-8a09570001156efe75be82648f4a0f78e3b0016357aa660d7120c6975943ddba">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RobotsTxtMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-58ad5ca4a766abd6f2a53f9984d20a8147fde67a3f20a6883e87698bade2ff9c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ScriptManagerMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-e9ae12bd9bdfcd97c45bdcc7c990b49e0922077cf7f8abd799e75524a18e7e55">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SiteAuditMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-0086b9e006016c221715fa102bdfcbd7938ea65c02a6277de9da4c8200b7316b">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SitemapMigrationPlan.cs</strong><dd><code>Disable current state check for migrations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/466/files#diff-939bf045e3e3f60b1d95d7444d0a9e8ded0ee64b07e35281fd36db6e4276fb03">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

