### PR TITLE
Fix racing condition for context routes

### DIFF
--- a/src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/CollectionManifests.ts
+++ b/src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/CollectionManifests.ts
@@ -38,7 +38,7 @@ const SiteAuditCollectionCreateAction: ManifestCollectionAction = {
     alias: 'seoToolkit.collections.siteAudits.createAction',
     meta: {
         label: '#general_create',
-        href: '/umbraco/section/SeoToolkit/workspace/st-siteAudit/create',
+        href: '/umbraco/section/SeoToolkit/workspace/st-create-siteAudit/create',
     },
     conditions: [
         {

--- a/src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/ModuleManifests.ts
+++ b/src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/ModuleManifests.ts
@@ -32,7 +32,7 @@ const SiteAuditCreateWorkspace: ManifestWorkspace = {
     name: 'SeoToolkit SiteAudit Create',
     api: () => import('../workspaces/SiteAuditCreateContext'),
     meta: {
-        entityType: 'st-siteAudit'
+        entityType: 'st-create-siteAudit'
     }
 }
 


### PR DESCRIPTION
### **User description**
Fixes https://github.com/patrickdemooij9/SeoToolkit.Umbraco/issues/468


___

### **PR Type**
Bug fix


___

### **Description**
- Fix racing condition by renaming context route from `st-siteAudit` to `st-create-siteAudit`

- Update workspace entity type and collection action href to use new route name


___



### File Walkthrough

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CollectionManifests.ts</strong><dd><code>Update collection action href route name</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/CollectionManifests.ts

<ul><li>Updated collection action href from <br><code>/umbraco/section/SeoToolkit/workspace/st-siteAudit/create</code> to <br><code>/umbraco/section/SeoToolkit/workspace/st-create-siteAudit/create</code><br> <li> Aligns the route name with the new context route naming convention</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/469/files#diff-400a79991a7815a06e2882c6283a923bce0ccc0762f48192a00c7cba42346e0c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ModuleManifests.ts</strong><dd><code>Update workspace entity type identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.SiteAudit/assets/src/manifests/ModuleManifests.ts

<ul><li>Changed workspace entity type from <code>st-siteAudit</code> to <code>st-create-siteAudit</code><br> <li> Resolves routing conflict by using distinct entity type for create <br>workspace</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/469/files#diff-03724bbfe217a8e14a11a2603a4b9f73108ae3e5f8982aaee7fbc6f024c2b0b6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

___

