### PR TITLE
Some fixes regarding the redirect UI

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
@@ -52,6 +52,7 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
 
   @state()
   _selectedContentName?: {
+    key: string;
     name: string;
     icon?: string;
   };
@@ -192,6 +193,9 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
       this._selectedContentName = undefined;
       return;
     }
+    if (contentKey === this._selectedContentName?.key) {
+      return;
+    }
     const docResponse = await this.#documentRepository.requestItems([
       contentKey,
     ]);
@@ -206,11 +210,13 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
     const selectedVariant = cultureVariant ?? invariantVariant;
     if (selectedVariant) {
       this._selectedContentName = {
+        key: contentKey,
         name: selectedVariant.name,
         icon: item?.documentType?.icon?.split(" ")[0],
       };
     } else {
       this._selectedContentName = {
+        key: contentKey,
         name: contentKey,
         icon: undefined,
       };

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
@@ -1,7 +1,11 @@
-import { UmbModalBaseElement } from "@umbraco-cms/backoffice/modal";
+import {
+  UmbModalBaseElement,
+  umbOpenModal,
+} from "@umbraco-cms/backoffice/modal";
 import { RedirectSelectLinkData } from "../models/RedirectSelectLinkData";
 import { UmbObjectState } from "@umbraco-cms/backoffice/observable-api";
 import {
+  css,
   customElement,
   html,
   state,
@@ -15,16 +19,26 @@ import { UmbPropertyTypeAppearanceModel } from "@umbraco-cms/backoffice/content-
 import { RedirectLinkType } from "../types/RedirectLinkType";
 import {
   UMB_APP_LANGUAGE_CONTEXT,
+  UmbAppLanguageContext,
   UmbLanguageCollectionRepository,
   UmbLanguageDetailModel,
 } from "@umbraco-cms/backoffice/language";
 import { UmbId } from "@umbraco-cms/backoffice/id";
+import {
+  UMB_DOCUMENT_PICKER_MODAL,
+  UmbDocumentItemModel,
+  UmbDocumentItemRepository,
+  UmbDocumentTreeItemModel,
+} from "@umbraco-cms/backoffice/document";
 
 @customElement("st-create-redirect-link-modal")
 export default class CreateRedirectLinkModal extends UmbModalBaseElement<
   RedirectSelectLinkData,
   RedirectSelectLinkData
 > {
+  #languageContext?: UmbAppLanguageContext;
+  #documentRepository = new UmbDocumentItemRepository(this);
+
   model?: UmbObjectState<RedirectSelectLinkData>;
 
   @state()
@@ -36,9 +50,22 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
   @state()
   _languages: Array<UmbLanguageDetailModel> = [];
 
+  @state()
+  _selectedContentName?: {
+    name: string;
+    icon?: string;
+  };
+
   propertyAppearance: UmbPropertyTypeAppearanceModel = {
     labelOnTop: false,
   };
+
+  constructor() {
+    super();
+    this.consumeContext(UMB_APP_LANGUAGE_CONTEXT, (instance) => {
+      this.#languageContext = instance;
+    });
+  }
 
   override async connectedCallback() {
     super.connectedCallback();
@@ -50,9 +77,25 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
 
     if (data) {
       this._languages = data.items;
+
+      const passedCulture = this.data?.culture;
+      let defaultCulture = this._languages[0]?.unique;
+
+      if (passedCulture) {
+        const matchedLanguage = this._languages.find(
+          (lan) =>
+            lan.unique === passedCulture ||
+            lan.name.toLowerCase() === passedCulture.toLowerCase(),
+        );
+        if (matchedLanguage) {
+          defaultCulture = matchedLanguage.unique;
+        }
+      }
+
       this.model.update({
-        culture: this._languages[0].unique,
+        culture: defaultCulture,
       });
+      this.#languageContext?.setLanguage(defaultCulture!);
     }
 
     this.observe(this.model.asObservable(), (value) => {
@@ -90,7 +133,85 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
         },
       ];
       this.linkType = value.linkType ?? RedirectLinkType.Url;
+
+      this.#loadContentName(this.model!.getValue().contentKey);
     });
+  }
+
+  async openDocumentPicker() {
+    const value = await umbOpenModal(this, UMB_DOCUMENT_PICKER_MODAL, {
+      data: {
+        hideTreeRoot: true,
+        pickableFilter: (
+          item: UmbDocumentItemModel | UmbDocumentTreeItemModel,
+        ) => {
+          if (
+            typeof item === "object" &&
+            item !== null &&
+            "noAccess" in item &&
+            item.noAccess === true
+          ) {
+            // https://github.com/umbraco/Umbraco-CMS/blob/main/src/Umbraco.Web.UI.Client/src/packages/documents/documents/tree/utils.ts#L8
+            return false;
+          }
+
+          const allowedStates = ["Published", "PublishedPendingChanges"];
+          const culture = this.model?.getValue().culture;
+          var cultureSpecificVariant = item.variants.find(
+            (variant) => variant.culture === culture,
+          );
+          if (
+            cultureSpecificVariant &&
+            allowedStates.includes(cultureSpecificVariant.state ?? "")
+          ) {
+            return true;
+          }
+          var globalVariant = item.variants.find(
+            (variant) => variant.culture === null,
+          );
+          if (
+            globalVariant &&
+            allowedStates.includes(globalVariant.state ?? "")
+          ) {
+            return true;
+          }
+          return false;
+        },
+      },
+    });
+    if (value.selection.length === 1) {
+      const selectedKey = value.selection[0]!;
+      this.model?.update({
+        contentKey: selectedKey,
+      });
+    }
+  }
+
+  async #loadContentName(contentKey?: string) {
+    if (!contentKey) {
+      this._selectedContentName = undefined;
+      return;
+    }
+    const docResponse = await this.#documentRepository.requestItems([
+      contentKey,
+    ]);
+    const item = docResponse.data?.[0];
+    const selectedVariant = item?.variants.find(
+      (variant) =>
+        variant.culture === this.model?.getValue().culture ||
+        variant.culture === null,
+    );
+    if (selectedVariant) {
+      this._selectedContentName = {
+        name: selectedVariant.name,
+        icon: item?.documentType?.icon?.split(" ")[0],
+      };
+    } else {
+      this._selectedContentName = {
+        name: contentKey,
+        icon: undefined,
+      };
+    }
   }
 
   #onPropertyDataChange(e: Event) {
@@ -106,12 +227,8 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
           return;
         }
         newValue[item.alias] = culture.unique;
-        this.modalContext?.consumeContext(
-          UMB_APP_LANGUAGE_CONTEXT,
-          (instance) => {
-            instance?.setLanguage(culture.unique);
-          },
-        );
+        this.#languageContext?.setLanguage(culture.unique);
+        newValue["contentKey"] = undefined;
       } else if (modelKeys.includes(item.alias)) {
         if (Array.isArray(item.value)) {
           if (item.alias === "mediaKey") {
@@ -203,20 +320,31 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
                   `,
                 )}
 
-                <umb-property
-                  alias="contentKey"
+                <umb-property-layout
                   label="Content"
-                  property-editor-ui-alias="Umb.PropertyEditorUi.DocumentPicker"
-                  val
-                  required
-                  .config=${[
-                    {
-                      alias: "max",
-                      value: 1,
-                    },
-                  ]}
+                  description="Select the content item you would like to connect to"
                 >
-                </umb-property>
+                  <div slot="editor">
+                    <uui-button
+                      .look="${this._selectedContentName
+                        ? "outline"
+                        : "placeholder"}"
+                      @click=${() => this.openDocumentPicker()}
+                      class="document-picker-button"
+                    >
+                      ${when(
+                        this._selectedContentName,
+                        () => html`
+                          <uui-icon
+                            name="${this._selectedContentName?.icon ?? "cube"}"
+                          ></uui-icon>
+                          ${this._selectedContentName?.name}
+                        `,
+                        () => "Select content",
+                      )}
+                    </uui-button>
+                  </div>
+                </umb-property-layout>
               `,
             )}
             ${when(
@@ -262,4 +390,10 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
       </umb-body-layout>
     `;
   }
+
+  static styles = css`
+    .document-picker-button {
+      width: 100%;
+    }
+  `;
 }

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts
@@ -196,11 +196,14 @@ export default class CreateRedirectLinkModal extends UmbModalBaseElement<
       contentKey,
     ]);
     const item = docResponse.data?.[0];
-    const selectedVariant = item?.variants.find(
-      (variant) =>
-        variant.culture === this.model?.getValue().culture ||
-        variant.culture === null,
+    const culture = this.model?.getValue().culture;
+    const cultureVariant = item?.variants.find(
+      (variant) => variant.culture === culture,
     );
+    const invariantVariant = item?.variants.find(
+      (variant) => variant.culture === null,
+    );
+    const selectedVariant = cultureVariant ?? invariantVariant;
     if (selectedVariant) {
       this._selectedContentName = {
         name: selectedVariant.name,

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
@@ -210,7 +210,7 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
   }
 
   #handleSubmit() {
-    if (!this.redirect?.value.oldUrl || !this.newUrlName || this.newUrlName === "[No URL available for selected culture]") {
+    if (!this.redirect?.value.oldUrl || !this.newUrlName) {
       this.showValidationMessage = true;
       this.requestUpdate();
       return;
@@ -319,8 +319,8 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
                   `,
                 )}
                 ${when(
-                  this.showValidationMessage && (!this.newUrlName || this.newUrlName === "[No URL available for selected culture]"),
-                  () => html`<div class="error">${this.newUrlName === "[No URL available for selected culture]" ? "No URL available for selected content in this culture" : "This field is required!"}</div>`,
+                  this.showValidationMessage && (!this.newUrlName),
+                  () => html`<div class="error">${"This field is required!"}</div>`,
                 )}
               </div>
             </umb-property-layout>

--- a/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
+++ b/src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts
@@ -110,9 +110,10 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
             this.#documentUrlRepository
               .requestItems([value.newNodeId!])
               .then((resp) => {
-                this.newUrlName = resp.data![0].urls.find(
+                const foundUrl = resp.data![0].urls.find(
                   (u) => u.culture === value.newCultureIso,
                 )?.url;
+                this.newUrlName = foundUrl || "[No URL available for selected culture]";
               });
           } else {
             this.#umbMediaUrlRepository
@@ -209,7 +210,7 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
   }
 
   #handleSubmit() {
-    if (!this.redirect?.value.oldUrl || !this.newUrlName) {
+    if (!this.redirect?.value.oldUrl || !this.newUrlName || this.newUrlName === "[No URL available for selected culture]") {
       this.showValidationMessage = true;
       this.requestUpdate();
       return;
@@ -318,8 +319,8 @@ export default class CreateRedirectModal extends UmbModalBaseElement<
                   `,
                 )}
                 ${when(
-                  this.showValidationMessage && !this.newUrlName,
-                  () => html`<div class="error">This field is required!</div>`,
+                  this.showValidationMessage && (!this.newUrlName || this.newUrlName === "[No URL available for selected culture]"),
+                  () => html`<div class="error">${this.newUrlName === "[No URL available for selected culture]" ? "No URL available for selected content in this culture" : "This field is required!"}</div>`,
                 )}
               </div>
             </umb-property-layout>


### PR DESCRIPTION
### **User description**
Fixes the following things:

When selecting a node that isn't published in the language, the new url field is empty. So I can submit the selection, but when I try to create the redirect, the validation says the new url can't be empty. Why can I select it from the content tree?

I open the Set link modal (picture 2), and the culture is set to English by default. If I've added a Dutch language or had Culture NL here, I get the Dutch content tree instead of the English one. The culture selection doesn't seem to reset when I open the modal (picture 3). Incidentally, it does pick up the unpublished (English) page when I submit.

I can click on Contact, which opens the editor for that page. However, the URL used is /edit/de10919a-4d2e-49a9-9292-72066e04d655, which displays an empty backoffice screen. Here is a part of the URL missing: /umbraco/section/content/workspace/document/


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix culture selection not persisting when opening document picker modal

- Replace document picker property with custom button to filter by published status

- Display selected content name with icon in redirect link modal

- Improve validation messaging for unavailable URLs in selected culture

- Reset content selection when culture changes to prevent mismatched variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User opens modal"] --> B["Culture context initialized"]
  B --> C["Document picker filters by culture"]
  C --> D["Selected content displayed with name"]
  D --> E["Validation checks URL availability"]
  F["Culture changes"] --> G["Content selection reset"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateRedirectLinkModal.element.ts</strong><dd><code>Implement custom document picker with culture filtering</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectLinkModal.element.ts

<ul><li>Added language context consumption in constructor to persist culture <br>selection<br> <li> Implemented custom document picker modal with culture-aware filtering <br>for published content only<br> <li> Added <code>_selectedContentName</code> state to display selected content with icon <br>and name<br> <li> Modified culture change handler to reset <code>contentKey</code> when culture is <br>switched<br> <li> Replaced built-in document picker property with custom button-based <br>picker UI<br> <li> Added CSS styling for full-width document picker button</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/474/files#diff-d0959b0b830eac8fc49ba5b1271e60e9850add98d23e153dbca7f49761e37a23">+154/-20</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CreateRedirectModal.element.ts</strong><dd><code>Improve URL validation and error messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/SeoToolkit.Umbraco.Redirects/assets/src/modals/CreateRedirectModal.element.ts

<ul><li>Added fallback message when URL is not available for selected culture<br> <li> Enhanced validation to reject submissions with unavailable culture <br>URLs<br> <li> Improved error messaging to distinguish between missing URL and <br>unavailable culture variant</ul>


</details>


  </td>
  <td><a href="https://github.com/patrickdemooij9/SeoToolkit.Umbraco/pull/474/files#diff-76fa31b3407f52b7fff3ce33bdc3b27fc3ccd7846673e3bc72adfe776397a8f4">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

