### PR TITLE
Add option to insert RedirectMiddleware on given position

### DIFF
--- a/src/SeoToolkit.Umbraco.Redirects.Core/Config/Models/RedirectMiddlewarePosition.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Config/Models/RedirectMiddlewarePosition.cs
@@ -1,0 +1,14 @@
+﻿namespace SeoToolkit.Umbraco.Redirects.Core.Config.Models
+{
+    /// <summary>
+    /// Values according to Umbraco documentation for custom middleware: https://docs.umbraco.com/umbraco-cms/reference/routing/custom-middleware
+    /// </summary>
+    public enum RedirectMiddlewarePosition
+    {
+        PrePipeline,
+        PreRouting,
+        PostRouting,
+        PostPipeline,
+        Endpoints
+    }
+}

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Config/Models/RedirectsAppSettingsModel.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Config/Models/RedirectsAppSettingsModel.cs
@@ -6,5 +6,6 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Config.Models
     {
         public string[] DisabledModules { get; set; } = Array.Empty<string>();
         public bool EnableBloomFilter { get; set; } = true;
+        public string RedirectMiddleWarePosition { get; set; }
     }
 }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Startup/RedirectsComposer.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Startup/RedirectsComposer.cs
@@ -60,17 +60,13 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Composers
             {
                 builder.Services.Configure<UmbracoPipelineOptions>(options =>
                 {
-                    options.AddFilter(new UmbracoPipelineFilter(
-                        "SeoToolkitRedirects",
-                        applicationBuilder =>
+                    options.AddFilter(new UmbracoPipelineFilter("SeoToolkitRedirects")
+                    {
+                        PostPipeline = applicationBuilder =>
                         {
                             applicationBuilder.UseMiddleware<RedirectMiddleware>();
-                        },
-                        applicationBuilder =>
-                        {
-                        },
-                        applicationBuilder => { }
-                    ));
+                        }
+                    });
                 });
             }
         }

--- a/src/SeoToolkit.Umbraco.Redirects.Core/Startup/RedirectsComposer.cs
+++ b/src/SeoToolkit.Umbraco.Redirects.Core/Startup/RedirectsComposer.cs
@@ -7,20 +7,19 @@ using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Web.Common.ApplicationBuilder;
 using Umbraco.Extensions;
+using SeoToolkit.Umbraco.Common.Core.Collections;
 using SeoToolkit.Umbraco.Common.Core.Constants;
 using SeoToolkit.Umbraco.Common.Core.Services.SettingsService;
+using SeoToolkit.Umbraco.Redirects.Core.BackgroundTasks;
+using SeoToolkit.Umbraco.Redirects.Core.Caching;
 using SeoToolkit.Umbraco.Redirects.Core.Components;
 using SeoToolkit.Umbraco.Redirects.Core.Config;
 using SeoToolkit.Umbraco.Redirects.Core.Config.Models;
-using SeoToolkit.Umbraco.Redirects.Core.Controllers;
 using SeoToolkit.Umbraco.Redirects.Core.Helpers;
 using SeoToolkit.Umbraco.Redirects.Core.Interfaces;
 using SeoToolkit.Umbraco.Redirects.Core.Middleware;
 using SeoToolkit.Umbraco.Redirects.Core.Repositories;
 using SeoToolkit.Umbraco.Redirects.Core.Services;
-using SeoToolkit.Umbraco.Redirects.Core.Caching;
-using SeoToolkit.Umbraco.Redirects.Core.BackgroundTasks;
-using SeoToolkit.Umbraco.Common.Core.Collections;
 using SeoToolkit.Umbraco.Redirects.Core.Startup;
 
 namespace SeoToolkit.Umbraco.Redirects.Core.Composers
@@ -33,7 +32,8 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Composers
             builder.Services.Configure<RedirectsAppSettingsModel>(section);
             builder.Services.AddSingleton(typeof(ISettingsService<RedirectsConfigModel>), typeof(RedirectsConfigurationService));
 
-            var disabledModules = section?.Get<RedirectsAppSettingsModel>()?.DisabledModules ?? Array.Empty<string>();
+            var appSettingsModel = section?.Get<RedirectsAppSettingsModel>();
+            var disabledModules = appSettingsModel?.DisabledModules ?? Array.Empty<string>();
 
             if (disabledModules.Contains(DisabledModuleConstant.All))
             {
@@ -58,14 +58,34 @@ namespace SeoToolkit.Umbraco.Redirects.Core.Composers
 
             if (!disabledModules.Contains(DisabledModuleConstant.Middleware))
             {
+                //Default to PrePipeline
+                var redirectMiddlewarePosition = RedirectMiddlewarePosition.PrePipeline;
+                var redirectMiddleWarePositionAppSetting = appSettingsModel.RedirectMiddleWarePosition;
+                if (!string.IsNullOrEmpty(redirectMiddleWarePositionAppSetting) &&
+                    Enum.TryParse(redirectMiddleWarePositionAppSetting, out RedirectMiddlewarePosition parsedValue))
+                {
+                    redirectMiddlewarePosition = parsedValue;
+                }
+
+                Action<IApplicationBuilder> middleware = applicationBuilder =>
+                {
+                    applicationBuilder.UseMiddleware<RedirectMiddleware>();
+                };
+
                 builder.Services.Configure<UmbracoPipelineOptions>(options =>
                 {
                     options.AddFilter(new UmbracoPipelineFilter("SeoToolkitRedirects")
                     {
-                        PostPipeline = applicationBuilder =>
-                        {
-                            applicationBuilder.UseMiddleware<RedirectMiddleware>();
-                        }
+                        PrePipeline = redirectMiddlewarePosition == RedirectMiddlewarePosition.PrePipeline ?
+                            middleware : null,
+                        PreRouting = redirectMiddlewarePosition == RedirectMiddlewarePosition.PreRouting ?
+                            middleware : null,
+                        PostRouting = redirectMiddlewarePosition == RedirectMiddlewarePosition.PostRouting ?
+                            middleware : null,
+                        PostPipeline = redirectMiddlewarePosition == RedirectMiddlewarePosition.PostPipeline ?
+                            middleware : null,
+                        Endpoints = redirectMiddlewarePosition == RedirectMiddlewarePosition.Endpoints ?
+                            middleware : null,
                     });
                 });
             }


### PR DESCRIPTION
Insert RedirectMiddleware on a given position so e.g. it will not conflict with umbracoUrlAlias.

We have a lot of documents with an umbracoUrlAlias and had some redirects based on a regex. In these occassions if the url matched the regex pattern it would redirect before umbraco could load the page. With this change the seotoolkitredirects can executed after all Umbraco middleware is executed.

Based on: https://docs.umbraco.com/umbraco-cms/reference/routing/custom-middleware