### PR TITLE
Fix SQLite syntax error in SitemapContentRepository.Delete

### DIFF
--- a/src/SeoToolkit.Umbraco.Sitemap.Core/Repositories/SitemapContentRepository.cs
+++ b/src/SeoToolkit.Umbraco.Sitemap.Core/Repositories/SitemapContentRepository.cs
@@ -44,7 +44,6 @@ namespace SeoToolkit.Umbraco.Sitemap.Core.Repositories
         {
             using var scope = _scopeProvider.CreateScope(autoComplete: true);
             scope.Database.Delete<SitemapContentEntity>(scope.SqlContext.Sql()
-                .SelectAll()
                 .From<SitemapContentEntity>()
                 .Where<SitemapContentEntity>(it => it.NodeKey == nodeKey));
         }


### PR DESCRIPTION
## Summary
`SitemapContentRepository.Delete(Guid nodeKey)` builds its `Sql` with `.SelectAll().From<…>().Where(…)` and passes it to `Database.Delete<T>(Sql sql)`. NPoco's overload **prefixes** the supplied SQL with `DELETE FROM <table>`, so the statement that reaches the database is:

```sql
DELETE FROM SitemapContentEntity SELECT * FROM SitemapContentEntity WHERE NodeKey = @0
```

SQLite rejects this with:

```
SQLite Error 1: 'near "SELECT": syntax error'
```

Stack (abridged, against 6.2.x on SQLite):

```
Microsoft.Data.Sqlite.SqliteException: SQLite Error 1: 'near "SELECT": syntax error'.
   …
   at NPoco.Database.Delete[T](Sql sql)
   at SeoToolkit.Umbraco.Sitemap.Core.Repositories.SitemapContentRepository.Delete(Guid nodeKey)
   at SeoToolkit.Umbraco.Sitemap.Core.Services.SitemapService.SitemapService.SetContentSettings(SitemapContentSettings settings)
   at SeoToolkit.Umbraco.Sitemap.Core.Controllers.SitemapContentController.SetContentSettings(SitemapContentSettingsPostModel model)
```

## Reproduction
1. Run on SQLite (default for the project template, Umbraco 17.x + SeoToolkit 6.2.x).
2. Open the Sitemap settings panel on a content node that has never had per-content sitemap overrides written (in practice this happens immediately for any newly created / not-yet-published node).
3. The backoffice POSTs the settings with all default values (`ExcludeFromSitemap=false`, no `ChangeFrequency`, no `Priority`). [`SitemapService.SetContentSettings`](https://github.com/patrickdemooij9/SeoToolkit.Umbraco/blob/dev/main/src/SeoToolkit.Umbraco.Sitemap.Core/Services/SitemapService/SitemapService.cs#L52-L62) sees `isDefault == true` and unconditionally calls `_sitemapContentRepository.Delete(...)` — even though no row exists — which throws.

## Fix
Drop the redundant `.SelectAll()` so the generated statement is `DELETE FROM <table> WHERE NodeKey = @0`. `Get` / `GetAll` are unchanged because their `FirstOrDefault` / `Fetch` paths legitimately need the `SELECT`.

## Related
Paired with #529, which guards the unconditional `Delete` call in `SitemapService.SetContentSettings` so it's only issued when a row actually exists. The two PRs are independent and can be merged in any order:
- This PR makes `Delete` correct on SQLite (where the unconditional call currently throws).
- #529 avoids issuing `Delete` at all when there's nothing to delete.

## Test plan
- [ ] Manual: with SQLite, open the sitemap panel on a newly created (unpublished) node and confirm no exception is logged.
- [ ] Manual: set a per-content override, then clear it back to defaults — row is removed cleanly.
- [ ] Manual: same flows on SQL Server (the bug was masked there because SQL Server's parser tolerates the stray clause differently — worth confirming behaviour hasn't regressed).