### PR TITLE
Skip Delete in SetContentSettings when no per-content row exists

### DIFF
--- a/src/SeoToolkit.Umbraco.Sitemap.Core/Services/SitemapService/SitemapService.cs
+++ b/src/SeoToolkit.Umbraco.Sitemap.Core/Services/SitemapService/SitemapService.cs
@@ -56,7 +56,10 @@ namespace SeoToolkit.Umbraco.Sitemap.Core.Services.SitemapService
 
             if (isDefault)
             {
-                _sitemapContentRepository.Delete(settings.NodeKey);
+                if (_sitemapContentRepository.Get(settings.NodeKey) is not null)
+                {
+                    _sitemapContentRepository.Delete(settings.NodeKey);
+                }
                 return;
             }
 


### PR DESCRIPTION
## Summary
[`SitemapService.SetContentSettings`](https://github.com/patrickdemooij9/SeoToolkit.Umbraco/blob/dev/main/src/SeoToolkit.Umbraco.Sitemap.Core/Services/SitemapService/SitemapService.cs#L53-L64) treats a payload of all-default values (`!ExcludeFromSitemap && string.IsNullOrEmpty(ChangeFrequency) && !Priority.HasValue`) as "clear the override" and calls `_sitemapContentRepository.Delete(...)` unconditionally — even when no row exists. For newly created / unpublished nodes (where the backoffice POSTs defaults on first interaction with the sitemap panel) this is a wasted DB round-trip every time the panel is opened.

Guard the `Delete` with a `Get` so the no-op case avoids the call entirely.

## Related
Paired with #528, which fixes the SQLite syntax error in `SitemapContentRepository.Delete` itself. The two PRs are independent and can be merged in any order:
- #528 makes `Delete` correct on SQLite (where the unconditional call currently throws).
- This PR avoids issuing `Delete` at all when there's nothing to delete.

After #528 alone, the unconditional `Delete` becomes a harmless no-op at the SQL layer (0 rows affected). This PR is polish, not a correctness fix — happy to drop it if you'd rather keep the service untouched.

## Test plan
- [ ] Manual: open the sitemap panel on a newly created (unpublished) node — no `DELETE` is issued.
- [ ] Manual: set a per-content override, then clear it back to defaults — `Get` finds the row, `Delete` runs, row is removed.
- [ ] Manual: clearing defaults a second time on the same node is a no-op (no `Delete` issued).