### PR TITLE
Bugfix/metafields save race

### DIFF
--- a/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
+++ b/src/SeoToolkit.Umbraco.MetaFields.Core/Services/MetaFieldsValueService/MetaFieldsValueService.cs
@@ -35,16 +35,26 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
         public void AddValues(int nodeId, Dictionary<string, object> values, string culture = null)
         {
             var foundCulture = culture.IfNullOrWhiteSpace(GetCulture());
-            foreach (var (key, value) in values)
+            try
             {
-                if (_repository.Exists(nodeId, key, foundCulture))
-                    _repository.Update(nodeId, key, foundCulture, value);
-                else
+                foreach (var (key, value) in values)
                 {
-                    _repository.Add(nodeId, key, foundCulture, value);
+                    if (_repository.Exists(nodeId, key, foundCulture))
+                        _repository.Update(nodeId, key, foundCulture, value);
+                    else
+                    {
+                        _repository.Add(nodeId, key, foundCulture, value);
+                    }
                 }
             }
-            ClearCache(nodeId);
+            finally
+            {
+                // Every repository call commits its own scope, so rows written
+                // before an exception are already persisted. Always clear the
+                // cache, otherwise reads keep serving the pre-save values until
+                // the cache expires.
+                ClearCache(nodeId);
+            }
         }
         
         public void Delete(int nodeId, string fieldAlias, string culture = null)
@@ -66,16 +76,26 @@ namespace SeoToolkit.Umbraco.MetaFields.Core.Services.SeoValueService
         public void AddValues(Guid nodeId, Dictionary<string, object> values, string culture = null)
         {
             var foundCulture = culture.IfNullOrWhiteSpace(GetCulture());
-            foreach (var (key, value) in values)
+            try
             {
-                if (_repository.Exists(nodeId, key, foundCulture))
-                    _repository.Update(nodeId, key, foundCulture, value);
-                else
+                foreach (var (key, value) in values)
                 {
-                    _repository.Add(nodeId, key, foundCulture, value);
+                    if (_repository.Exists(nodeId, key, foundCulture))
+                        _repository.Update(nodeId, key, foundCulture, value);
+                    else
+                    {
+                        _repository.Add(nodeId, key, foundCulture, value);
+                    }
                 }
             }
-            ClearCache(nodeId);
+            finally
+            {
+                // Every repository call commits its own scope, so rows written
+                // before an exception are already persisted. Always clear the
+                // cache, otherwise reads keep serving the pre-save values until
+                // the cache expires.
+                ClearCache(nodeId);
+            }
         }
 
 

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
@@ -8,11 +8,15 @@ import type { MetaFieldsAIFieldSuggestion } from "../dataAccess/MetaFieldsAISour
 import { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
 import { UMB_DOCUMENT_WORKSPACE_CONTEXT } from "@umbraco-cms/backoffice/document";
 import { UmbBooleanState, UmbObjectState } from "@umbraco-cms/backoffice/observable-api";
+import { UMB_NOTIFICATION_CONTEXT } from "@umbraco-cms/backoffice/notification";
 
 interface MetaFieldsSettingsVariant {
   variant: string;
   model: UmbObjectState<MetaFieldsSettingsViewModel>;
   isDirty: boolean;
+  // Bumped on every local edit so save() can tell whether the model changed
+  // while its request was in flight.
+  editVersion: number;
 }
 
 export default class MetaFieldsContentContext
@@ -113,6 +117,9 @@ export default class MetaFieldsContentContext
     Object.values(this.#variants).forEach((variant) => {
       variant.model.setValue({ seoEnabled: false });
       variant.isDirty = false;
+      // Invalidate any in-flight save so its response cannot be applied on top
+      // of the node we just switched to.
+      variant.editVersion++;
     });
   }
 
@@ -147,6 +154,7 @@ export default class MetaFieldsContentContext
         seoEnabled: false,
       }),
       isDirty: false,
+      editVersion: 0,
     };
     return this.#variants[variant];
   }
@@ -171,16 +179,38 @@ export default class MetaFieldsContentContext
       }
     });
 
+    const editVersionAtSave = variant.editVersion;
     const resp = await this.#repository.save({
       nodeId: this.#nodeId,
       culture: culture,
       userValues: userValues,
     });
 
+    // tryExecute never throws; a failed request comes back as an error without
+    // data. Leave the variant dirty so the next document save retries, and tell
+    // the editor — the document itself saved fine, so nothing else will.
+    if (!resp || resp.error || !resp.data) {
+      this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
+        instance?.peek("danger", {
+          data: {
+            headline: "SEO",
+            message:
+              "The SEO meta fields could not be saved. Your changes are still here — save the page again to retry.",
+          },
+        });
+      });
+      return;
+    }
+
+    // Edits made while the request was in flight are not in the response;
+    // applying it would wipe them. Keep the variant dirty so the next document
+    // save picks them up.
+    if (variant.editVersion !== editVersionAtSave) return;
+
     // Reconcile with what was actually persisted, otherwise this model keeps
     // serving the values it was first loaded with for the rest of the session.
-    const data = resp?.data;
-    if (data && data.seoEnabled !== false) {
+    const data = resp.data;
+    if (data.seoEnabled !== false) {
       variant.model.update(data);
     }
     variant.isDirty = false;
@@ -202,6 +232,7 @@ export default class MetaFieldsContentContext
       userValue: userValue,
     };
     entry.isDirty = true;
+    entry.editVersion++;
     entry.model.update({
       fields: updated,
     });
@@ -223,6 +254,7 @@ export default class MetaFieldsContentContext
       }
     }
     entry.isDirty = true;
+    entry.editVersion++;
     entry.model.update({ fields: updated });
   }
 

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
@@ -17,6 +17,11 @@ interface MetaFieldsSettingsVariant {
   // Bumped on every local edit so save() can tell whether the model changed
   // while its request was in flight.
   editVersion: number;
+  // A document save can emit multiple updateDate changes in quick succession
+  // (e.g. save + publish). Concurrent POSTs race the server's exists/insert
+  // check, so while one is in flight further saves only queue a follow-up.
+  saving: boolean;
+  saveQueued: boolean;
 }
 
 export default class MetaFieldsContentContext
@@ -155,6 +160,8 @@ export default class MetaFieldsContentContext
       }),
       isDirty: false,
       editVersion: 0,
+      saving: false,
+      saveQueued: false,
     };
     return this.#variants[variant];
   }
@@ -166,6 +173,32 @@ export default class MetaFieldsContentContext
   async save(culture: string) {
     const variant = this.#variants[culture];
     if (!variant || !this.#nodeId) return;
+
+    if (variant.saving) {
+      variant.saveQueued = true;
+      return;
+    }
+
+    variant.saving = true;
+    try {
+      await this.#performSave(variant, culture);
+    } finally {
+      variant.saving = false;
+    }
+
+    if (variant.saveQueued) {
+      variant.saveQueued = false;
+      // Only worth another request when something is still unsaved — either
+      // edits that arrived mid-flight or a save attempt that failed.
+      if (variant.isDirty) {
+        await this.save(culture);
+      }
+    }
+  }
+
+  async #performSave(variant: MetaFieldsSettingsVariant, culture: string) {
+    const nodeId = this.#nodeId;
+    if (!nodeId) return;
 
     const model = variant.model.getValue();
     if (model.seoEnabled === false) return;
@@ -181,15 +214,18 @@ export default class MetaFieldsContentContext
 
     const editVersionAtSave = variant.editVersion;
     const resp = await this.#repository.save({
-      nodeId: this.#nodeId,
+      nodeId: nodeId,
       culture: culture,
       userValues: userValues,
     });
 
     // tryExecute never throws; a failed request comes back as an error without
     // data. Leave the variant dirty so the next document save retries, and tell
-    // the editor — the document itself saved fine, so nothing else will.
+    // the editor — the document itself saved fine, so nothing else will. When a
+    // follow-up save is already queued, let that attempt decide instead of
+    // showing an error for a state that may recover on its own.
     if (!resp || resp.error || !resp.data) {
+      if (variant.saveQueued) return;
       this.consumeContext(UMB_NOTIFICATION_CONTEXT, (instance) => {
         instance?.peek("danger", {
           data: {

--- a/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
+++ b/src/SeoToolkit.Umbraco.MetaFields/assets/src/workspaces/MetaFieldsContentContext.ts
@@ -14,12 +14,7 @@ interface MetaFieldsSettingsVariant {
   variant: string;
   model: UmbObjectState<MetaFieldsSettingsViewModel>;
   isDirty: boolean;
-  // Bumped on every local edit so save() can tell whether the model changed
-  // while its request was in flight.
   editVersion: number;
-  // A document save can emit multiple updateDate changes in quick succession
-  // (e.g. save + publish). Concurrent POSTs race the server's exists/insert
-  // check, so while one is in flight further saves only queue a follow-up.
   saving: boolean;
   saveQueued: boolean;
 }
@@ -312,4 +307,3 @@ export default class MetaFieldsContentContext
 
 export const ST_METAFIELDS_CONTENT_TOKEN_CONTEXT =
   new UmbContextToken<MetaFieldsContentContext>("ST-MetaFieldsContent-Context");
-


### PR DESCRIPTION
Three separate issues stacked on top of each other:

1. **A failed save was treated as a successful one.** When the meta fields POST
   failed, the client still marked the fields as "clean", so later document saves
   skipped them entirely and the edits were silently lost. Edits typed while a
   save request was still running were also overwritten by the response.

2. **One click could fire two save requests.** "Save and publish" changes the
   document's `updateDate` twice in quick succession, and each change triggered its
   own meta fields POST. On the *first* save of a node both requests pass the
   server's "does this row exist?" check and both insert — the loser crashes with
   the UNIQUE constraint error. (Hard to reproduce: it only happens on a node's
   first save, and only when the two requests actually overlap.)

3. **A failed save left the cache stale for 30 minutes.** When the save threw
   halfway, the cache invalidation at the end of `AddValues` never ran, so that
   node kept serving the old values on every reload — making it look like the
   node was permanently broken.